### PR TITLE
bump version requirements for 2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,10 +32,10 @@
     ],
     "require": {
         "php": "^7.0|^7.1",
-        "magento/framework": "^100.1|^101.0",
+        "magento/framework": "^100.1|^101.0|^102.0",
         "magento/zendframework1": "^1.12",
-        "magento/module-catalog": "^101.0|^102.0",
-        "magento/module-customer": "^100.1|^101.0",
+        "magento/module-catalog": "^101.0|^102.0|^103.0",
+        "magento/module-customer": "^100.1|^101.0|^102.0",
         "magento/module-checkout": "^100.1",
         "magento/module-indexer": "^100.0"
     },


### PR DESCRIPTION
Magento 2.3 is releasing nov 27th. I'm currently using this library on 2.3 beta and everything seems to work properly, therefore bumping version requirements in composer.json.