### PR TITLE
use a new quote for each order fixture

### DIFF
--- a/src/Checkout/CustomerCheckout.php
+++ b/src/Checkout/CustomerCheckout.php
@@ -161,7 +161,9 @@ class CustomerCheckout
         $reloadedQuote = $this->quoteRepository->get($this->cart->getQuote()->getId());
         // Collect missing totals, like shipping
         $reloadedQuote->collectTotals();
-        return $this->quoteManagement->submit($reloadedQuote);
+        $order = $this->quoteManagement->submit($reloadedQuote);
+        $this->cart->getCheckoutSession()->clearQuote();
+        return $order;
     }
 
     private function saveBilling()


### PR DESCRIPTION
When creating multiple order fixtrures in a row using the tddwizard/magento2-fixtures package, then all orders are created from the same quote because it does not get cleaned up in the checkout session.

This pr intends to fix this issue.