### PR TITLE
Add phpunit.xml to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 /composer.lock
+/tests/phpunit.xml


### PR DESCRIPTION
Add `test/phpunit.xml` to `.gitignore` file list to not disrupt version control when using a custom copy of `test/phpunit.xml.dist`