### PR TITLE
Use faker to generate customer addresses

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,9 @@
         "magento/module-catalog": "^101.0|^102.0|^103.0",
         "magento/module-customer": "^100.1|^101.0|^102.0",
         "magento/module-checkout": "^100.1",
-        "magento/module-indexer": "^100.0"
+        "magento/module-indexer": "^100.0",
+        "fzaninotto/faker": "^v1.9.0"
+
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0|^6.0",

--- a/tests/Customer/CustomerBuilderTest.php
+++ b/tests/Customer/CustomerBuilderTest.php
@@ -3,7 +3,6 @@
 namespace TddWizard\Fixtures\Customer;
 
 use Magento\Customer\Api\CustomerRepositoryInterface;
-use Magento\Customer\Model\Customer;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\TestFramework\Helper\Bootstrap;
@@ -148,5 +147,23 @@ class CustomerBuilderTest extends TestCase
         $this->assertEquals('52078', $address->getPostcode());
         $this->assertEquals('Aachen', $address->getCity());
         $this->assertEquals(88, $address->getRegionId());
+    }
+
+    /**
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function testLocalizedAddresses()
+    {
+        $customerFixture = new CustomerFixture(
+            CustomerBuilder::aCustomer()->withAddresses(
+                AddressBuilder::anAddress(null, 'de_DE')->asDefaultBilling(),
+                AddressBuilder::anAddress(null, 'en_US')->asDefaultShipping()
+            )->build()
+        );
+
+        foreach ($this->customerRepository->getById($customerFixture->getId())->getAddresses() as $address) {
+            self::assertSame($address->isDefaultBilling() ? 'DE' : 'US', $address->getCountryId());
+        }
     }
 }


### PR DESCRIPTION
## Changed

Use `fzaninotto/faker` library to generate fake customer addresses in `AddressBuilder`.

## Added

Fake addresses can be localised via a optional argument on `AddressBuilder::anAddress`.