### PR TITLE
Add 'Sales' Builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,10 +202,15 @@ Logged-in customer, products, and cart item quantities will be
 generated internally unless more control is desired:
 
 ```php
-$order = OrderBuilder::anOrder()->withProducts(
-    ProductBuilder::aSimpleProduct()->withSku('foo'),
-    ProductBuilder::aSimpleProduct()->withSku('bar')
-)->build();
+$order = OrderBuilder::anOrder()
+    ->withProducts(
+        // prepare catalog product fixtures
+        ProductBuilder::aSimpleProduct()->withSku('foo'),
+        ProductBuilder::aSimpleProduct()->withSku('bar')
+    )->withCart(
+        // define cart item quantities
+        CartBuilder::forCurrentSession()->withSimpleProduct('foo', 2)->withSimpleProduct('bar', 3)
+    )->build();
 ```
 
 ### Shipment

--- a/README.md
+++ b/README.md
@@ -190,3 +190,70 @@ $order = $checkout
   ->placeOrder();
 ```
 
+### Order
+
+The `OrderBuilder` is a shortcut for checkout simulation.
+
+```php
+$order = OrderBuilder::anOrder()->build(); 
+```
+
+Logged-in customer, products, and cart item quantities will be
+generated internally unless more control is desired:
+
+```php
+$order = OrderBuilder::anOrder()->withProducts(
+    ProductBuilder::aSimpleProduct()->withSku('foo'),
+    ProductBuilder::aSimpleProduct()->withSku('bar')
+)->build();
+```
+
+### Shipment
+
+Orders can be fully or partially shipped, optionally with tracks.
+
+```php
+$order = OrderBuilder::anOrder()->build();
+
+// ship everything
+$shipment = ShipmentBuilder::forOrder($order)->build();
+// ship only given order items, add tracks
+$shipment = ShipmentBuilder::forOrder($order)
+    ->withItem($fooItemId, $fooQtyToShip)
+    ->withItem($barItemId, $barQtyToShip)
+    ->withTrackingNumbers('123-FOO', '456-BAR')
+    ->build();
+```
+
+### Invoice
+
+Orders can be fully or partially invoiced.
+
+```php
+$order = OrderBuilder::anOrder()->build();
+
+// invoice everything
+$invoice = InvoiceBuilder::forOrder($order)->build();
+// invoice only given order items
+$invoice = InvoiceBuilder::forOrder($order)
+    ->withItem($fooItemId, $fooQtyToInvoice)
+    ->withItem($barItemId, $barQtyToInvoice)
+    ->build();
+```
+
+### Credit Memo
+
+Credit memos can be created for either all or some of the items ordered.
+An invoice to refund will be created internally.
+
+```php
+$order = OrderBuilder::anOrder()->build();
+
+// refund everything
+$creditmemo = CreditmemoBuilder::forOrder($order)->build();
+// refund only given order items
+$creditmemo = CreditmemoBuilder::forOrder($order)
+    ->withItem($fooItemId, $fooQtyToRefund)
+    ->withItem($barItemId, $barQtyToRefund)
+    ->build();
+```

--- a/src/Sales/CreditmemoBuilder.php
+++ b/src/Sales/CreditmemoBuilder.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace TddWizard\Fixtures\Sales;
+
+use Magento\Framework\ObjectManagerInterface;
+use Magento\Sales\Api\CreditmemoRepositoryInterface;
+use Magento\Sales\Api\Data\CreditmemoInterface;
+use Magento\Sales\Api\Data\CreditmemoItemCreationInterfaceFactory;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Api\RefundOrderInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+
+/**
+ * Builder to be used by fixtures
+ */
+class CreditmemoBuilder
+{
+    /**
+     * @var CreditmemoItemCreationInterfaceFactory
+     */
+    private $itemFactory;
+
+    /**
+     * @var RefundOrderInterface
+     */
+    private $refundOrder;
+
+    /**
+     * @var CreditmemoRepositoryInterface
+     */
+    private $creditmemoRepository;
+
+    /**
+     * @var OrderInterface
+     */
+    private $order;
+
+    /**
+     * @var int[]
+     */
+    private $orderItems;
+
+    public function __construct(
+        CreditmemoItemCreationInterfaceFactory $itemFactory,
+        RefundOrderInterface $refundOrder,
+        CreditmemoRepositoryInterface $creditmemoRepository,
+        OrderInterface $order
+    ) {
+        $this->itemFactory = $itemFactory;
+        $this->refundOrder = $refundOrder;
+        $this->creditmemoRepository = $creditmemoRepository;
+        $this->order = $order;
+
+        $this->orderItems = [];
+    }
+
+    public static function forOrder(
+        OrderInterface $order,
+        ObjectManagerInterface $objectManager = null
+    ): CreditmemoBuilder {
+        if ($objectManager === null) {
+            $objectManager = Bootstrap::getObjectManager();
+        }
+
+        return new static(
+            $objectManager->create(CreditmemoItemCreationInterfaceFactory::class),
+            $objectManager->create(RefundOrderInterface::class),
+            $objectManager->create(CreditmemoRepositoryInterface::class),
+            $order
+        );
+    }
+
+    public function withItem(int $orderItemId, int $qty): CreditmemoBuilder
+    {
+        $builder = clone $this;
+
+        $builder->orderItems[$orderItemId] = $qty;
+
+        return $builder;
+    }
+
+    public function build(): CreditmemoInterface
+    {
+        // order must be invoiced before a refund can be created.
+        if ($this->order->canInvoice()) {
+            InvoiceBuilder::forOrder($this->order)->build();
+        }
+
+        // refund items must be explicitly set
+        if (empty($this->orderItems)) {
+            foreach ($this->order->getItems() as $item) {
+                $this->orderItems[$item->getItemId()] = $item->getQtyOrdered();
+            }
+        }
+
+        $creditmemoItems = [];
+        foreach ($this->orderItems as $orderItemId => $qty) {
+            $creditmemoItem = $this->itemFactory->create();
+            $creditmemoItem->setOrderItemId($orderItemId);
+            $creditmemoItem->setQty($qty);
+            $creditmemoItems[] = $creditmemoItem;
+        }
+
+        $creditmemoId = $this->refundOrder->execute($this->order->getEntityId(), $creditmemoItems);
+
+        return $this->creditmemoRepository->get($creditmemoId);
+    }
+}

--- a/src/Sales/CreditmemoFixture.php
+++ b/src/Sales/CreditmemoFixture.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace TddWizard\Fixtures\Sales;
+
+use Magento\Sales\Api\Data\CreditmemoInterface;
+
+class CreditmemoFixture
+{
+    /**
+     * @var CreditmemoInterface
+     */
+    private $creditmemo;
+
+    public function __construct(CreditmemoInterface $creditmemo)
+    {
+        $this->creditmemo = $creditmemo;
+    }
+
+    public function getId(): int
+    {
+        return (int) $this->creditmemo->getEntityId();
+    }
+}

--- a/src/Sales/InvoiceBuilder.php
+++ b/src/Sales/InvoiceBuilder.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace TddWizard\Fixtures\Sales;
+
+use Magento\Framework\ObjectManagerInterface;
+use Magento\Sales\Api\Data\InvoiceInterface;
+use Magento\Sales\Api\Data\InvoiceItemCreationInterfaceFactory;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Api\InvoiceOrderInterface;
+use Magento\Sales\Api\InvoiceRepositoryInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+
+/**
+ * Builder to be used by fixtures
+ */
+class InvoiceBuilder
+{
+    /**
+     * @var InvoiceItemCreationInterfaceFactory
+     */
+    private $itemFactory;
+
+    /**
+     * @var InvoiceOrderInterface
+     */
+    private $invoiceOrder;
+
+    /**
+     * @var InvoiceRepositoryInterface
+     */
+    private $invoiceRepository;
+
+    /**
+     * @var OrderInterface
+     */
+    private $order;
+
+    /**
+     * @var int[]
+     */
+    private $orderItems;
+
+    public function __construct(
+        InvoiceItemCreationInterfaceFactory $itemFactory,
+        InvoiceOrderInterface $invoiceOrder,
+        InvoiceRepositoryInterface $invoiceRepository,
+        OrderInterface $order
+    ) {
+        $this->itemFactory = $itemFactory;
+        $this->invoiceOrder = $invoiceOrder;
+        $this->invoiceRepository = $invoiceRepository;
+        $this->order = $order;
+
+        $this->orderItems = [];
+    }
+
+    public static function forOrder(
+        OrderInterface $order,
+        ObjectManagerInterface $objectManager = null
+    ): InvoiceBuilder {
+        if ($objectManager === null) {
+            $objectManager = Bootstrap::getObjectManager();
+        }
+
+        return new static(
+            $objectManager->create(InvoiceItemCreationInterfaceFactory::class),
+            $objectManager->create(InvoiceOrderInterface::class),
+            $objectManager->create(InvoiceRepositoryInterface::class),
+            $order
+        );
+    }
+
+    public function withItem(int $orderItemId, int $qty): InvoiceBuilder
+    {
+        $builder = clone $this;
+
+        $builder->orderItems[$orderItemId] = $qty;
+
+        return $builder;
+    }
+
+    public function build(): InvoiceInterface
+    {
+        $invoiceItems = [];
+
+        foreach ($this->orderItems as $orderItemId => $qty) {
+            $invoiceItem = $this->itemFactory->create();
+            $invoiceItem->setOrderItemId($orderItemId);
+            $invoiceItem->setQty($qty);
+            $invoiceItems[] = $invoiceItem;
+        }
+
+        $invoiceId = $this->invoiceOrder->execute($this->order->getEntityId(), false, $invoiceItems);
+
+        return $this->invoiceRepository->get($invoiceId);
+    }
+}

--- a/src/Sales/InvoiceFixture.php
+++ b/src/Sales/InvoiceFixture.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace TddWizard\Fixtures\Sales;
+
+use Magento\Sales\Api\Data\InvoiceInterface;
+
+class InvoiceFixture
+{
+    /**
+     * @var InvoiceInterface
+     */
+    private $invoice;
+
+    public function __construct(InvoiceInterface $shipment)
+    {
+        $this->invoice = $shipment;
+    }
+
+    public function getId(): int
+    {
+        return (int) $this->invoice->getEntityId();
+    }
+}

--- a/src/Sales/OrderBuilder.php
+++ b/src/Sales/OrderBuilder.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace TddWizard\Fixtures\Sales;
+
+use Magento\Sales\Api\Data\OrderInterface;
+use TddWizard\Fixtures\Catalog\ProductBuilder;
+use TddWizard\Fixtures\Checkout\CartBuilder;
+use TddWizard\Fixtures\Checkout\CustomerCheckout;
+use TddWizard\Fixtures\Customer\AddressBuilder;
+use TddWizard\Fixtures\Customer\CustomerBuilder;
+use TddWizard\Fixtures\Customer\CustomerFixture;
+
+/**
+ * Builder to be used by fixtures
+ */
+class OrderBuilder
+{
+    /**
+     * @var CartBuilder
+     */
+    private $cartBuilder;
+
+    /**
+     * @var ProductBuilder[]
+     */
+    private $productBuilders;
+
+    /**
+     * @var CustomerBuilder
+     */
+    private $customerBuilder;
+
+    /**
+     * @var string
+     */
+    private $shippingMethod;
+
+    /**
+     * @var string
+     */
+    private $paymentMethod;
+
+    public static function anOrder(): OrderBuilder
+    {
+        return new static();
+    }
+
+    public function withProducts(ProductBuilder ...$productBuilders): OrderBuilder
+    {
+        $builder = clone $this;
+        $builder->productBuilders = $productBuilders;
+
+        return $builder;
+    }
+
+    public function withCustomer(CustomerBuilder $customerBuilder): OrderBuilder
+    {
+        $builder = clone $this;
+        $builder->customerBuilder = $customerBuilder;
+
+        return $builder;
+    }
+
+    public function withCart(CartBuilder $cartBuilder): OrderBuilder
+    {
+        $builder = clone $this;
+        $builder->cartBuilder = $cartBuilder;
+
+        return $builder;
+    }
+
+    public function withShippingMethod(string $shippingMethod): OrderBuilder
+    {
+        $builder = clone $this;
+        $builder->shippingMethod = $shippingMethod;
+
+        return $builder;
+    }
+
+    public function withPaymentMethod(string $paymentMethod): OrderBuilder
+    {
+        $builder = clone $this;
+        $builder->paymentMethod = $paymentMethod;
+
+        return $builder;
+    }
+
+    /**
+     * @return OrderInterface
+     * @throws \Exception
+     */
+    public function build(): OrderInterface
+    {
+        $builder = clone $this;
+
+        if (empty($builder->productBuilders)) {
+            // init simple products
+            for ($i = 0; $i < 3; $i++) {
+                $builder->productBuilders[] = ProductBuilder::aSimpleProduct();
+            }
+        }
+
+        // create products
+        $products = array_map(
+            static function (ProductBuilder $productBuilder) {
+                return $productBuilder->build();
+            },
+            $builder->productBuilders
+        );
+
+        if (empty($builder->customerBuilder)) {
+            // init customer
+            $builder->customerBuilder = CustomerBuilder::aCustomer()
+                ->withAddresses(AddressBuilder::anAddress()->asDefaultBilling()->asDefaultShipping());
+        }
+
+        // log customer in
+        $customer = $builder->customerBuilder->build();
+        $customerFixture = new CustomerFixture($customer);
+        $customerFixture->login();
+
+        if (empty($builder->cartBuilder)) {
+            // init cart, add products
+            $builder->cartBuilder = CartBuilder::forCurrentSession();
+            foreach ($products as $product) {
+                $qty = 1;
+                $builder->cartBuilder = $builder->cartBuilder->withSimpleProduct($product->getSku(), $qty);
+            }
+        }
+
+        // check out, place order
+        $checkout = CustomerCheckout::fromCart($builder->cartBuilder->build());
+        if ($builder->shippingMethod) {
+            $checkout = $checkout->withShippingMethodCode($builder->shippingMethod);
+        }
+
+        if ($builder->paymentMethod) {
+            $checkout = $checkout->withPaymentMethodCode($builder->paymentMethod);
+        }
+
+        return $checkout->placeOrder();
+    }
+}

--- a/src/Sales/OrderFixture.php
+++ b/src/Sales/OrderFixture.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace TddWizard\Fixtures\Sales;
+
+use Magento\Sales\Api\Data\OrderInterface;
+
+class OrderFixture
+{
+    /**
+     * @var OrderInterface
+     */
+    private $order;
+
+    public function __construct(OrderInterface $order)
+    {
+        $this->order = $order;
+    }
+
+    public function getId(): int
+    {
+        return (int) $this->order->getEntityId();
+    }
+
+    public function getCustomerId(): int
+    {
+        return (int) $this->order->getCustomerId();
+    }
+
+    public function getCustomerEmail(): string
+    {
+        return (string) $this->order->getCustomerEmail();
+    }
+
+    /**
+     * Obtain `qty_ordered` per order item, indexed with `item_id`.
+     *
+     * @return int[]
+     */
+    public function getOrderItemQtys(): array
+    {
+        $qtys = [];
+        foreach ($this->order->getItems() as $item) {
+            $qtys[$item->getItemId()] = $item->getQtyOrdered();
+        }
+
+        return $qtys;
+    }
+
+    public function getPaymentMethod(): string
+    {
+        return $this->order->getPayment()->getMethod();
+    }
+
+    public function getShippingMethod(): string
+    {
+        return $this->order->getShippingMethod();
+    }
+}

--- a/src/Sales/OrderFixtureRollback.php
+++ b/src/Sales/OrderFixtureRollback.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace TddWizard\Fixtures\Sales;
+
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\ObjectManagerInterface;
+use Magento\Framework\Registry;
+use Magento\Sales\Api\Data\OrderItemInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+
+class OrderFixtureRollback
+{
+    /**
+     * @var Registry
+     */
+    private $registry;
+
+    /**
+     * @var OrderRepositoryInterface
+     */
+    private $orderRepository;
+
+    /**
+     * @var CustomerRepositoryInterface
+     */
+    private $customerRepository;
+
+    /**
+     * @var ProductRepositoryInterface
+     */
+    private $productRepository;
+
+    public function __construct(
+        Registry $registry,
+        OrderRepositoryInterface $orderRepository,
+        CustomerRepositoryInterface $customerRepository,
+        ProductRepositoryInterface $productRepository
+    ) {
+        $this->registry = $registry;
+        $this->orderRepository = $orderRepository;
+        $this->customerRepository = $customerRepository;
+        $this->productRepository = $productRepository;
+    }
+
+    public static function create(ObjectManagerInterface $objectManager = null)
+    {
+        if ($objectManager === null) {
+            $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        }
+
+        return new self(
+            $objectManager->get(Registry::class),
+            $objectManager->get(OrderRepositoryInterface::class),
+            $objectManager->get(CustomerRepositoryInterface::class),
+            $objectManager->get(ProductRepositoryInterface::class)
+        );
+    }
+
+    /**
+     * Roll back orders with associated customers and products.
+     *
+     * @param OrderFixture ...$orderFixtures
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
+    public function execute(OrderFixture ...$orderFixtures)
+    {
+        $this->registry->unregister('isSecureArea');
+        $this->registry->register('isSecureArea', true);
+
+        foreach ($orderFixtures as $orderFixture) {
+            $orderItems = $this->orderRepository->get($orderFixture->getId())->getItems();
+
+            $this->orderRepository->deleteById($orderFixture->getId());
+            $this->customerRepository->deleteById($orderFixture->getCustomerId());
+            array_walk(
+                $orderItems,
+                function (OrderItemInterface $orderItem) {
+                    $this->productRepository->deleteById($orderItem->getSku());
+                }
+            );
+        }
+
+        $this->registry->unregister('isSecureArea');
+    }
+}

--- a/src/Sales/ShipmentBuilder.php
+++ b/src/Sales/ShipmentBuilder.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace TddWizard\Fixtures\Sales;
+
+use Magento\Framework\ObjectManagerInterface;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Api\Data\ShipmentInterface;
+use Magento\Sales\Api\Data\ShipmentItemCreationInterfaceFactory;
+use Magento\Sales\Api\Data\ShipmentTrackCreationInterfaceFactory;
+use Magento\Sales\Api\ShipmentRepositoryInterface;
+use Magento\Sales\Api\ShipOrderInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+
+/**
+ * Builder to be used by fixtures
+ */
+class ShipmentBuilder
+{
+    /**
+     * @var ShipmentItemCreationInterfaceFactory
+     */
+    private $itemFactory;
+
+    /**
+     * @var ShipmentTrackCreationInterfaceFactory
+     */
+    private $trackFactory;
+
+    /**
+     * @var ShipOrderInterface
+     */
+    private $shipOrder;
+
+    /**
+     * @var ShipmentRepositoryInterface
+     */
+    private $shipmentRepository;
+
+    /**
+     * @var OrderInterface
+     */
+    private $order;
+
+    /**
+     * @var int[]
+     */
+    private $orderItems;
+
+    /**
+     * @var string[]
+     */
+    private $trackingNumbers;
+
+    public function __construct(
+        ShipmentItemCreationInterfaceFactory $itemFactory,
+        ShipmentTrackCreationInterfaceFactory $trackFactory,
+        ShipOrderInterface $shipOrder,
+        ShipmentRepositoryInterface $shipmentRepository,
+        OrderInterface $order
+    ) {
+        $this->itemFactory = $itemFactory;
+        $this->trackFactory = $trackFactory;
+        $this->shipOrder = $shipOrder;
+        $this->shipmentRepository = $shipmentRepository;
+        $this->order = $order;
+
+        $this->orderItems = [];
+        $this->trackingNumbers = [];
+    }
+
+    public static function forOrder(
+        OrderInterface $order,
+        ObjectManagerInterface $objectManager = null
+    ): ShipmentBuilder {
+        if ($objectManager === null) {
+            $objectManager = Bootstrap::getObjectManager();
+        }
+
+        return new static(
+            $objectManager->create(ShipmentItemCreationInterfaceFactory::class),
+            $objectManager->create(ShipmentTrackCreationInterfaceFactory::class),
+            $objectManager->create(ShipOrderInterface::class),
+            $objectManager->create(ShipmentRepositoryInterface::class),
+            $order
+        );
+    }
+
+    public function withItem(int $orderItemId, int $qty): ShipmentBuilder
+    {
+        $builder = clone $this;
+
+        $builder->orderItems[$orderItemId] = $qty;
+
+        return $builder;
+    }
+
+    public function withTrackingNumbers(string ...$trackingNumbers): ShipmentBuilder
+    {
+        $builder = clone $this;
+
+        $builder->trackingNumbers = $trackingNumbers;
+
+        return $builder;
+    }
+
+    public function build(): ShipmentInterface
+    {
+        $shipmentItems = [];
+
+        foreach ($this->orderItems as $orderItemId => $qty) {
+            $shipmentItem = $this->itemFactory->create();
+            $shipmentItem->setOrderItemId($orderItemId);
+            $shipmentItem->setQty($qty);
+            $shipmentItems[] = $shipmentItem;
+        }
+
+        $tracks = array_map(
+            function (string $trackingNumber) {
+                $carrierCode = strtok($this->order->getShippingMethod(), '_');
+                $track = $this->trackFactory->create();
+                $track->setCarrierCode($carrierCode);
+                $track->setTitle($carrierCode);
+                $track->setTrackNumber($trackingNumber);
+
+                return $track;
+            },
+            $this->trackingNumbers
+        );
+
+        $shipmentId = $this->shipOrder->execute(
+            $this->order->getEntityId(),
+            $shipmentItems,
+            false,
+            false,
+            null,
+            $tracks
+        );
+
+        $shipment = $this->shipmentRepository->get($shipmentId);
+        if (!empty($this->trackingNumbers)) {
+            $shipment->setShippingLabel('%PDF-1.4');
+            $this->shipmentRepository->save($shipment);
+        }
+
+        return $shipment;
+    }
+}

--- a/src/Sales/ShipmentFixture.php
+++ b/src/Sales/ShipmentFixture.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace TddWizard\Fixtures\Sales;
+
+use Magento\Sales\Api\Data\ShipmentInterface;
+
+class ShipmentFixture
+{
+    /**
+     * @var ShipmentInterface
+     */
+    private $shipment;
+
+    public function __construct(ShipmentInterface $shipment)
+    {
+        $this->shipment = $shipment;
+    }
+
+    public function getId(): int
+    {
+        return (int) $this->shipment->getEntityId();
+    }
+
+    public function getTracks(): array
+    {
+        return $this->shipment->getTracks();
+    }
+
+    public function getShippingLabel(): string
+    {
+        return (string) $this->shipment->getShippingLabel();
+    }
+}

--- a/tests/Sales/CreditmemoBuilderTest.php
+++ b/tests/Sales/CreditmemoBuilderTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace TddWizard\Fixtures\Sales;
+
+use Magento\Sales\Api\CreditmemoRepositoryInterface;
+use Magento\Sales\Api\Data\CreditmemoInterface;
+use Magento\Sales\Api\Data\OrderItemInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+use TddWizard\Fixtures\Catalog\ProductBuilder;
+use TddWizard\Fixtures\Checkout\CartBuilder;
+
+/**
+ * @magentoAppIsolation enabled
+ * @magentoDbIsolation enabled
+ */
+class CreditmemoBuilderTest extends TestCase
+{
+    /**
+     * @var OrderFixture
+     */
+    private $orderFixture;
+
+    /**
+     * @var CreditmemoRepositoryInterface
+     */
+    private $creditmemoRepository;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->creditmemoRepository = Bootstrap::getObjectManager()->create(CreditmemoRepositoryInterface::class);
+    }
+
+    /**
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    protected function tearDown()
+    {
+        OrderFixtureRollback::create()->execute($this->orderFixture);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Create a credit memo for all the order's items.
+     *
+     * @test
+     *
+     * @throws \Exception
+     */
+    public function createCreditmemo()
+    {
+        $order = OrderBuilder::anOrder()->withPaymentMethod('checkmo')->build();
+        $this->orderFixture = new OrderFixture($order);
+
+        $refundFixture = new CreditmemoFixture(CreditmemoBuilder::forOrder($order)->build());
+
+        self::assertInstanceOf(CreditmemoInterface::class, $this->creditmemoRepository->get($refundFixture->getId()));
+        self::assertFalse($order->canCreditmemo());
+    }
+
+    /**
+     * Create a credit memo for some of the order's items.
+     *
+     * @test
+     * @throws \Exception
+     */
+    public function createPartialCreditmemos()
+    {
+        $order = OrderBuilder::anOrder()->withPaymentMethod('checkmo')->withProducts(
+            ProductBuilder::aSimpleProduct()->withSku('foo'),
+            ProductBuilder::aSimpleProduct()->withSku('bar')
+        )->withCart(
+            CartBuilder::forCurrentSession()
+                ->withSimpleProduct('foo', 2)
+                ->withSimpleProduct('bar', 3)
+        )->build();
+        $this->orderFixture = new OrderFixture($order);
+
+        $orderItemIds = [];
+        /** @var OrderItemInterface $orderItem */
+        foreach ($order->getAllVisibleItems() as $orderItem) {
+            $orderItemIds[$orderItem->getSku()] = $orderItem->getItemId();
+        }
+
+        $refundFixture = new CreditmemoFixture(
+            CreditmemoBuilder::forOrder($order)
+                ->withItem($orderItemIds['foo'], 2)
+                ->withItem($orderItemIds['bar'], 2)
+                ->build()
+        );
+
+        self::assertInstanceOf(CreditmemoInterface::class, $this->creditmemoRepository->get($refundFixture->getId()));
+        self::assertTrue($order->canCreditmemo());
+
+        $refundFixture = new CreditmemoFixture(
+            CreditmemoBuilder::forOrder($order)
+                ->withItem($orderItemIds['bar'], 1)
+                ->build()
+        );
+
+        self::assertInstanceOf(CreditmemoInterface::class, $this->creditmemoRepository->get($refundFixture->getId()));
+        self::assertFalse($order->canCreditmemo());
+    }
+}

--- a/tests/Sales/InvoiceBuilderTest.php
+++ b/tests/Sales/InvoiceBuilderTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace TddWizard\Fixtures\Sales;
+
+use Magento\Sales\Api\Data\InvoiceInterface;
+use Magento\Sales\Api\Data\OrderItemInterface;
+use Magento\Sales\Api\InvoiceRepositoryInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+use TddWizard\Fixtures\Catalog\ProductBuilder;
+use TddWizard\Fixtures\Checkout\CartBuilder;
+
+/**
+ * @magentoAppIsolation enabled
+ * @magentoDbIsolation enabled
+ */
+class InvoiceBuilderTest extends TestCase
+{
+    /**
+     * @var OrderFixture
+     */
+    private $orderFixture;
+
+    /**
+     * @var InvoiceRepositoryInterface
+     */
+    private $invoiceRepository;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->invoiceRepository = Bootstrap::getObjectManager()->create(InvoiceRepositoryInterface::class);
+    }
+
+    /**
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    protected function tearDown()
+    {
+        OrderFixtureRollback::create()->execute($this->orderFixture);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Create a invoice for all the order's items.
+     *
+     * @test
+     *
+     * @throws \Exception
+     */
+    public function createInvoice()
+    {
+        $order = OrderBuilder::anOrder()->build();
+        $this->orderFixture = new OrderFixture($order);
+
+        $invoiceFixture = new InvoiceFixture(InvoiceBuilder::forOrder($order)->build());
+
+        self::assertInstanceOf(InvoiceInterface::class, $this->invoiceRepository->get($invoiceFixture->getId()));
+        self::assertFalse($order->canInvoice());
+    }
+
+    /**
+     * Create an invoice for some of the order's items.
+     *
+     * @test
+     * @throws \Exception
+     */
+    public function createPartialInvoices()
+    {
+        $order = OrderBuilder::anOrder()->withProducts(
+            ProductBuilder::aSimpleProduct()->withSku('foo'),
+            ProductBuilder::aSimpleProduct()->withSku('bar')
+        )->withCart(
+            CartBuilder::forCurrentSession()
+                ->withSimpleProduct('foo', 2)
+                ->withSimpleProduct('bar', 3)
+        )->build();
+        $this->orderFixture = new OrderFixture($order);
+
+        $orderItemIds = [];
+        /** @var OrderItemInterface $orderItem */
+        foreach ($order->getAllVisibleItems() as $orderItem) {
+            $orderItemIds[$orderItem->getSku()] = $orderItem->getItemId();
+        }
+
+        $invoiceFixture = new InvoiceFixture(
+            InvoiceBuilder::forOrder($order)
+                ->withItem($orderItemIds['foo'], 2)
+                ->withItem($orderItemIds['bar'], 2)
+                ->build()
+        );
+
+        self::assertInstanceOf(InvoiceInterface::class, $this->invoiceRepository->get($invoiceFixture->getId()));
+        self::assertTrue($order->canInvoice());
+
+        $invoiceFixture = new InvoiceFixture(
+            InvoiceBuilder::forOrder($order)
+                ->withItem($orderItemIds['bar'], 1)
+                ->build()
+        );
+
+        self::assertInstanceOf(InvoiceInterface::class, $this->invoiceRepository->get($invoiceFixture->getId()));
+        self::assertFalse($order->canInvoice());
+    }
+}

--- a/tests/Sales/OrderBuilderTest.php
+++ b/tests/Sales/OrderBuilderTest.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace TddWizard\Fixtures\Sales;
+
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+use TddWizard\Fixtures\Catalog\ProductBuilder;
+use TddWizard\Fixtures\Checkout\CartBuilder;
+use TddWizard\Fixtures\Customer\AddressBuilder;
+use TddWizard\Fixtures\Customer\CustomerBuilder;
+
+/**
+ * @magentoAppIsolation enabled
+ * @magentoDbIsolation enabled
+ */
+class OrderBuilderTest extends TestCase
+{
+    /**
+     * @var OrderFixture
+     */
+    private $orderFixture;
+
+    /**
+     * @var OrderRepositoryInterface
+     */
+    private $orderRepository;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->orderRepository = Bootstrap::getObjectManager()->create(OrderRepositoryInterface::class);
+    }
+
+    /**
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    protected function tearDown()
+    {
+        OrderFixtureRollback::create()->execute($this->orderFixture);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Create an order for an internally generated customer and internally generated product(s).
+     *
+     * Easy to set up, least flexible.
+     *
+     * @test
+     * @throws \Exception
+     */
+    public function createOrder()
+    {
+        $this->orderFixture = new OrderFixture(
+            OrderBuilder::anOrder()->build()
+        );
+
+        self::assertInstanceOf(OrderInterface::class, $this->orderRepository->get($this->orderFixture->getId()));
+        self::assertNotEmpty($this->orderFixture->getOrderItemQtys());
+    }
+
+    /**
+     * Create an order for an internally generated customer.
+     *
+     * Control the product included with the order, use random item quantities.
+     *
+     * @test
+     * @throws \Exception
+     */
+    public function createOrderWithProduct()
+    {
+        $this->orderFixture = new OrderFixture(
+            OrderBuilder::anOrder()->withProducts(ProductBuilder::aSimpleProduct())->build()
+        );
+
+        self::assertInstanceOf(OrderInterface::class, $this->orderRepository->get($this->orderFixture->getId()));
+        self::assertCount(1, $this->orderFixture->getOrderItemQtys());
+    }
+
+    /**
+     * Create an order for an internally generated customer with multiple products.
+     *
+     * Control the products included with the order, use random item quantities.
+     *
+     * @test
+     * @throws \Exception
+     */
+    public function createOrderWithProducts()
+    {
+        $this->orderFixture = new OrderFixture(
+            OrderBuilder::anOrder()->withProducts(
+                ProductBuilder::aSimpleProduct()->withSku('foo'),
+                ProductBuilder::aSimpleProduct()->withSku('bar')
+            )->build()
+        );
+
+        self::assertInstanceOf(OrderInterface::class, $this->orderRepository->get($this->orderFixture->getId()));
+        self::assertCount(2, $this->orderFixture->getOrderItemQtys());
+    }
+
+    /**
+     * Create an order for a given customer with internally generated product(s).
+     *
+     * Control the customer placing the order.
+     *
+     * @test
+     * @throws \Exception
+     */
+    public function createOrderWithCustomer()
+    {
+        $customerEmail = 'test@example.com';
+        $customerBuilder = CustomerBuilder::aCustomer()
+            ->withEmail($customerEmail)
+            ->withAddresses(AddressBuilder::anAddress()->asDefaultBilling()->asDefaultShipping());
+
+        $this->orderFixture = new OrderFixture(
+            OrderBuilder::anOrder()->withCustomer($customerBuilder)->build()
+        );
+
+        self::assertInstanceOf(OrderInterface::class, $this->orderRepository->get($this->orderFixture->getId()));
+        self::assertSame($customerEmail, $this->orderFixture->getCustomerEmail());
+        self::assertNotEmpty($this->orderFixture->getOrderItemQtys());
+    }
+
+    /**
+     * Create an order for a given cart.
+     *
+     * Complex to set up, most flexible:
+     * - define products
+     * - define customer
+     * - set item quantities
+     * - set payment and shipping method
+     *
+     * @test
+     * @throws \Exception
+     */
+    public function createOrderWithCart()
+    {
+        $cartItems = ['foo' => 2, 'bar' => 3];
+        $customerEmail = 'test@example.com';
+        $paymentMethod = 'checkmo';
+        $shippingMethod = 'flatrate_flatrate';
+
+        $productBuilders = [];
+        foreach ($cartItems as $sku => $qty) {
+            $productBuilders[] = ProductBuilder::aSimpleProduct()->withSku($sku);
+        }
+
+        $customerBuilder = CustomerBuilder::aCustomer();
+        $customerBuilder = $customerBuilder
+            ->withEmail($customerEmail)
+            ->withAddresses(AddressBuilder::anAddress()->asDefaultBilling()->asDefaultShipping());
+
+        $cartBuilder = CartBuilder::forCurrentSession();
+        foreach ($cartItems as $sku => $qty) {
+            $cartBuilder = $cartBuilder->withSimpleProduct($sku, $qty);
+        }
+
+        $this->orderFixture = new OrderFixture(
+            OrderBuilder::anOrder()
+                ->withProducts(...$productBuilders)
+                ->withCustomer($customerBuilder)
+                ->withCart($cartBuilder)
+                ->withPaymentMethod($paymentMethod)->withShippingMethod($shippingMethod)
+                ->build()
+        );
+
+        self::assertInstanceOf(OrderInterface::class, $this->orderRepository->get($this->orderFixture->getId()));
+        self::assertSame($customerEmail, $this->orderFixture->getCustomerEmail());
+        self::assertEmpty(array_diff($cartItems, $this->orderFixture->getOrderItemQtys()));
+        self::assertSame($paymentMethod, $this->orderFixture->getPaymentMethod());
+        self::assertSame($shippingMethod, $this->orderFixture->getShippingMethod());
+    }
+}

--- a/tests/Sales/ShipmentBuilderTest.php
+++ b/tests/Sales/ShipmentBuilderTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace TddWizard\Fixtures\Sales;
+
+use Magento\Sales\Api\Data\OrderItemInterface;
+use Magento\Sales\Api\Data\ShipmentInterface;
+use Magento\Sales\Api\Data\ShipmentTrackInterface;
+use Magento\Sales\Api\ShipmentRepositoryInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+use TddWizard\Fixtures\Catalog\ProductBuilder;
+use TddWizard\Fixtures\Checkout\CartBuilder;
+
+/**
+ * @magentoAppIsolation enabled
+ * @magentoDbIsolation enabled
+ */
+class ShipmentBuilderTest extends TestCase
+{
+    /**
+     * @var OrderFixture
+     */
+    private $orderFixture;
+
+    /**
+     * @var ShipmentRepositoryInterface
+     */
+    private $shipmentRepository;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->shipmentRepository = Bootstrap::getObjectManager()->create(ShipmentRepositoryInterface::class);
+    }
+
+    /**
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    protected function tearDown()
+    {
+        OrderFixtureRollback::create()->execute($this->orderFixture);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Create a shipment for all the order's items.
+     *
+     * @test
+     *
+     * @throws \Exception
+     */
+    public function createShipment()
+    {
+        $order = OrderBuilder::anOrder()->build();
+        $this->orderFixture = new OrderFixture($order);
+
+        $shipmentFixture = new ShipmentFixture(ShipmentBuilder::forOrder($order)->build());
+
+        self::assertInstanceOf(ShipmentInterface::class, $this->shipmentRepository->get($shipmentFixture->getId()));
+        self::assertEmpty($shipmentFixture->getShippingLabel());
+        self::assertEmpty($shipmentFixture->getTracks());
+        self::assertFalse($order->canShip());
+    }
+
+    /**
+     * Create a shipment for all the order's items with tracks and shipping label.
+     *
+     * @test
+     *
+     * @throws \Exception
+     */
+    public function createShipmentWithTracks()
+    {
+        $order = OrderBuilder::anOrder()->build();
+        $this->orderFixture = new OrderFixture($order);
+
+        $shipmentFixture = new ShipmentFixture(
+            ShipmentBuilder::forOrder($order)->withTrackingNumbers('123456', '987654', 'abcdef')->build()
+        );
+
+        self::assertInstanceOf(ShipmentInterface::class, $this->shipmentRepository->get($shipmentFixture->getId()));
+
+        self::assertNotEmpty($shipmentFixture->getShippingLabel());
+        self::assertNotEmpty($shipmentFixture->getTracks());
+        self::assertContainsOnlyInstancesOf(ShipmentTrackInterface::class, $shipmentFixture->getTracks());
+        self::assertCount(3, $shipmentFixture->getTracks());
+        self::assertFalse($order->canShip());
+    }
+
+    /**
+     * Create a shipment for some of the order's items.
+     *
+     * @test
+     * @throws \Exception
+     */
+    public function createPartialShipments()
+    {
+        $order = OrderBuilder::anOrder()->withProducts(
+            ProductBuilder::aSimpleProduct()->withSku('foo'),
+            ProductBuilder::aSimpleProduct()->withSku('bar')
+        )->withCart(
+            CartBuilder::forCurrentSession()
+                ->withSimpleProduct('foo', 2)
+                ->withSimpleProduct('bar', 3)
+        )->build();
+        $this->orderFixture = new OrderFixture($order);
+
+        $orderItemIds = [];
+        /** @var OrderItemInterface $orderItem */
+        foreach ($order->getAllVisibleItems() as $orderItem) {
+            $orderItemIds[$orderItem->getSku()] = $orderItem->getItemId();
+        }
+
+        $shipmentFixture = new ShipmentFixture(
+            ShipmentBuilder::forOrder($order)
+                ->withItem($orderItemIds['foo'], 2)
+                ->withItem($orderItemIds['bar'], 2)
+                ->build()
+        );
+
+        self::assertInstanceOf(ShipmentInterface::class, $this->shipmentRepository->get($shipmentFixture->getId()));
+        self::assertTrue($order->canShip());
+
+        $shipmentFixture = new ShipmentFixture(
+            ShipmentBuilder::forOrder($order)
+                ->withItem($orderItemIds['bar'], 1)
+                ->build()
+        );
+
+        self::assertInstanceOf(ShipmentInterface::class, $this->shipmentRepository->get($shipmentFixture->getId()));
+        self::assertFalse($order->canShip());
+    }
+}


### PR DESCRIPTION
Thie PR introduces the following Builders (plus Fixtures) for Entities provided by the Magento "Sales" module: 

- OrderBuilder
- ShipmentBuilder
- InvoiceBuilder
- CreditmemoBuilder

Usage examples are provided via tests and via additional sections in the README file.