### PR TITLE
CI-239: fix placing multiple orders

### DIFF
--- a/src/Customer/CustomerFixture.php
+++ b/src/Customer/CustomerFixture.php
@@ -82,4 +82,14 @@ class CustomerFixture
         }
         $session->setCustomerId($this->getId());
     }
+
+    public function logout(Session $session = null)
+    {
+        if ($session === null) {
+            $objectManager = Bootstrap::getObjectManager();
+            $session = $objectManager->get(Session::class);
+        }
+
+        $session->logout();
+    }
 }

--- a/src/Sales/OrderBuilder.php
+++ b/src/Sales/OrderBuilder.php
@@ -138,6 +138,10 @@ class OrderBuilder
             $checkout = $checkout->withPaymentMethodCode($builder->paymentMethod);
         }
 
-        return $checkout->placeOrder();
+        $order = $checkout->placeOrder();
+
+        $customerFixture->logout();
+
+        return $order;
     }
 }


### PR DESCRIPTION
When creating multiple orders in a row (e.g. setting up several order fixtures for mass action testing), then [`\Magento\Quote\Model\QuoteAddressValidator::doValidate`](https://github.com/magento/magento2/blob/2.3.4/app/code/Magento/Quote/Model/QuoteAddressValidator.php#L97-L99) fails with an "Invalid customer address id" exception if the order gets created [`withCart`](https://github.com/tddwizard/magento2-fixtures/blob/v0.9.0/src/Sales/OrderBuilder.php#L64-L70), because the address has the customer ID of the _previous_ order assigned. I did not get to the bottom of why exactly this happens. Creating the cart builder before logging the customer in is part of the issue.

The workaround is to have the order builder log the customer out after the order was placed. It is the order builder which initially logged the customer in, so it is just appropriate to reverse that / clean up state there.