### PR TITLE
Fix building addresses with province

### DIFF
--- a/src/Customer/AddressBuilder.php
+++ b/src/Customer/AddressBuilder.php
@@ -44,7 +44,14 @@ class AddressBuilder
 
         $faker = FakerFactory::create($locale);
         $countryCode = substr($locale, -2);
-        $regionId = $objectManager->create(Region::class)->loadByName($faker->state, $countryCode)->getId();
+
+        try {
+            $region = $faker->province;
+        } catch (\InvalidArgumentException $exception) {
+            $region = $faker->state;
+        }
+
+        $regionId = $objectManager->create(Region::class)->loadByName($region, $countryCode)->getId();
 
         /** @var AddressInterface $address */
         $address = $objectManager->create(AddressInterface::class);

--- a/src/Customer/CustomerFixture.php
+++ b/src/Customer/CustomerFixture.php
@@ -82,4 +82,14 @@ class CustomerFixture
         }
         $session->setCustomerId($this->getId());
     }
+
+    public function logout(Session $session = null)
+    {
+        if ($session === null) {
+            $objectManager = Bootstrap::getObjectManager();
+            $session = $objectManager->get(Session::class);
+        }
+
+        $session->logout();
+    }
 }

--- a/src/Sales/OrderBuilder.php
+++ b/src/Sales/OrderBuilder.php
@@ -138,6 +138,10 @@ class OrderBuilder
             $checkout = $checkout->withPaymentMethodCode($builder->paymentMethod);
         }
 
-        return $checkout->placeOrder();
+        $order = $checkout->placeOrder();
+
+        $customerFixture->logout();
+
+        return $order;
     }
 }

--- a/tests/Sales/OrderBuilderTest.php
+++ b/tests/Sales/OrderBuilderTest.php
@@ -235,4 +235,50 @@ class OrderBuilderTest extends TestCase
         $customerIds[$orderWithCustomerFixture->getCustomerId()] = 1;
         self::assertCount(3, $customerIds);
     }
+
+    /**
+     * Create orders for faker addresses with either state or province. Assert both types have a `region_id` assigned.
+     *
+     * @test
+     * @throws \Exception
+     */
+    public function createIntlOrders()
+    {
+        $atLocale = 'de_AT';
+        $atOrder = OrderBuilder::anOrder()
+            ->withCustomer(
+                CustomerBuilder::aCustomer()->withAddresses(
+                    AddressBuilder::anAddress(null, $atLocale)->asDefaultBilling()->asDefaultShipping()
+                )
+            )
+            ->build();
+        $this->orderFixtures[] = new OrderFixture($atOrder);
+
+        $usLocale = 'en_US';
+        $usOrder = OrderBuilder::anOrder()
+            ->withCustomer(
+                CustomerBuilder::aCustomer()->withAddresses(
+                    AddressBuilder::anAddress(null, $usLocale)->asDefaultBilling()->asDefaultShipping()
+                )
+            )
+            ->build();
+        $this->orderFixtures[] = new OrderFixture($usOrder);
+
+        $caLocale = 'en_CA';
+        $caOrder = OrderBuilder::anOrder()
+            ->withCustomer(
+                CustomerBuilder::aCustomer()->withAddresses(
+                    AddressBuilder::anAddress(null, $caLocale)->asDefaultBilling()->asDefaultShipping()
+                )
+            )
+            ->build();
+        $this->orderFixtures[] = new OrderFixture($caOrder);
+
+        self::assertSame(substr($atLocale, 3, 4), $atOrder->getBillingAddress()->getCountryId());
+        self::assertNotEmpty($atOrder->getBillingAddress()->getRegionId());
+        self::assertSame(substr($usLocale, 3, 4), $usOrder->getBillingAddress()->getCountryId());
+        self::assertNotEmpty($usOrder->getBillingAddress()->getRegionId());
+        self::assertSame(substr($caLocale, 3, 4), $caOrder->getBillingAddress()->getCountryId());
+        self::assertNotEmpty($caOrder->getBillingAddress()->getRegionId());
+    }
 }


### PR DESCRIPTION
Region ID is not properly determined when the Faker address has a `province` property (instead of the more common `state`).

For CA addresses, the `QuoteValidator` then throws a `LocalizedException` when using the OrderBuilder:

> Please check the shipping address information. "regionId" is required. Enter and try again.

This change attempts to read `province` first and falls back to `state` if the former is not set.

**Note**: This builds upon #41 and has to be merged thereafter.