### PR TITLE
Establish M2.4 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ Install it into your Magento 2 project with composer:
 If you need a customer without specific data, this is all:
 
 ```php
-protected function setUp()
+protected function setUp(): void
 {
   $this->customerFixture = new CustomerFixture(
     CustomerBuilder::aCustomer()->build()
   );
 }
-protected function tearDown()
+protected function tearDown(): void
 {
   CustomerFixtureRollback::create()->execute($this->customerFixture);
 }
@@ -98,7 +98,7 @@ $this->customerFixture->login();
 
 
 
-### Adresses
+### Addresses
 
 Similar to the customer builder you can also configure the address builder with custom attributes:
 
@@ -120,7 +120,7 @@ AddressBuilder::anAddress()
 Product fixtures work similar as customer fixtures:
 
 ```php
-protected function setUp()
+protected function setUp(): void
 {
   $this->productFixture = new ProductFixture(
     ProductBuilder::aSimpleProduct()
@@ -133,7 +133,7 @@ protected function setUp()
       ->build()
   );
 }
-protected function tearDown()
+protected function tearDown(): void
 {
   ProductFixtureRollback::create()->execute($this->productFixture);
 }

--- a/composer.json
+++ b/composer.json
@@ -30,21 +30,27 @@
         }
     ],
     "require": {
-        "php": "^7.0",
-        "magento/framework": "^101.0|^102.0",
-        "magento/zendframework1": "^1.12",
-        "magento/module-catalog": "^101.0|^102.0|^103.0",
-        "magento/module-customer": "^100.1|^101.0|^102.0",
-        "magento/module-checkout": "^100.1",
-        "magento/module-indexer": "^100.0",
+        "php": "^7.1",
+        "magento/framework": "^102.0|^103.0",
+        "magento/zendframework1": "^1.14",
+        "magento/module-catalog": "^103.0|^104.0",
+        "magento/module-catalog-inventory": "^100.3",
+        "magento/module-checkout": "^100.3",
+        "magento/module-customer": "^102.0|^103.0",
+        "magento/module-directory": "^100.3",
+        "magento/module-indexer": "^100.3",
+        "magento/module-payment": "^100.3",
+        "magento/module-quote": "^101.1",
+        "magento/module-sales": "^102.0|^103.0",
         "fzaninotto/faker": "^v1.9.0"
-
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0|^6.0",
+        "ext-json": "*",
+        "magento/module-store": "^101.0",
+        "phpunit/phpunit": "^6.0|^9.0",
         "pds/skeleton": "^1.0",
-        "phpro/grumphp": "^0.11.6",
-        "phpstan/phpstan": "^0.8.0",
+        "phpro/grumphp": "^0.13.0",
+        "phpstan/phpstan": "^0.9.0",
         "squizlabs/php_codesniffer": "^3.0"
     }
 }

--- a/registration.php
+++ b/registration.php
@@ -1,4 +1,5 @@
 <?php
+
 \Magento\Framework\Component\ComponentRegistrar::register(
     \Magento\Framework\Component\ComponentRegistrar::MODULE,
     'TddWizard_Fixtures',

--- a/src/Catalog/CategoryBuilder.php
+++ b/src/Catalog/CategoryBuilder.php
@@ -4,20 +4,16 @@ namespace TddWizard\Fixtures\Catalog;
 
 use Magento\Catalog\Api\CategoryLinkRepositoryInterface;
 use Magento\Catalog\Api\CategoryRepositoryInterface;
-use Magento\Catalog\Model\Category;
-use \Magento\Catalog\Model\ResourceModel\Category as CategoryResource;
 use Magento\Catalog\Api\Data\CategoryInterface;
 use Magento\Catalog\Api\Data\CategoryProductLinkInterface;
 use Magento\Catalog\Api\Data\CategoryProductLinkInterfaceFactory;
+use Magento\Catalog\Model\Category;
+use Magento\Catalog\Model\ResourceModel\Category as CategoryResource;
 use Magento\Framework\ObjectManagerInterface;
+use Magento\TestFramework\Helper\Bootstrap;
 
 class CategoryBuilder
 {
-    /**
-     * @var CategoryInterface
-     */
-    private $category;
-
     /**
      * @var CategoryRepositoryInterface
      */
@@ -39,9 +35,14 @@ class CategoryBuilder
     private $productLinkFactory;
 
     /**
+     * @var CategoryInterface|Category
+     */
+    private $category;
+
+    /**
      * @var int[]
      */
-    private $skus = [];
+    private $skus;
 
     public function __construct(
         CategoryRepositoryInterface $categoryRepository,
@@ -54,15 +55,15 @@ class CategoryBuilder
         $this->categoryRepository = $categoryRepository;
         $this->categoryResource = $categoryResource;
         $this->categoryLinkRepository = $categoryLinkRepository;
+        $this->productLinkFactory = $productLinkFactory;
         $this->category = $category;
         $this->skus = $skus;
-        $this->productLinkFactory = $productLinkFactory;
     }
 
-    public static function topLevelCategory(ObjectManagerInterface $objectManager = null) : CategoryBuilder
+    public static function topLevelCategory(ObjectManagerInterface $objectManager = null): CategoryBuilder
     {
         if ($objectManager === null) {
-            $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+            $objectManager = Bootstrap::getObjectManager();
         }
         /** @var CategoryInterface $category */
         $category = $objectManager->create(CategoryInterface::class);
@@ -84,10 +85,9 @@ class CategoryBuilder
     public static function childCategoryOf(
         CategoryFixture $parent,
         ObjectManagerInterface $objectManager = null
-    ): CategoryBuilder
-    {
+    ): CategoryBuilder {
         if ($objectManager === null) {
-            $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+            $objectManager = Bootstrap::getObjectManager();
         }
         /** @var CategoryInterface $category */
         $category = $objectManager->create(CategoryInterface::class);
@@ -112,35 +112,35 @@ class CategoryBuilder
      * @param string[] $skus
      * @return CategoryBuilder
      */
-    public function withProducts(array $skus) : CategoryBuilder
+    public function withProducts(array $skus): CategoryBuilder
     {
         $builder = clone $this;
         $builder->skus = $skus;
         return $builder;
     }
 
-    public function withDescription(string $description) : CategoryBuilder
+    public function withDescription(string $description): CategoryBuilder
     {
         $builder = clone $this;
         $builder->category->setCustomAttribute('description', $description);
         return $builder;
     }
 
-    public function withName(string $name) : CategoryBuilder
+    public function withName(string $name): CategoryBuilder
     {
         $builder = clone $this;
         $builder->category->setName($name);
         return $builder;
     }
 
-    public function withUrlKey(string $urlKey) : CategoryBuilder
+    public function withUrlKey(string $urlKey): CategoryBuilder
     {
         $builder = clone $this;
         $builder->category->setData('url_key', $urlKey);
         return $builder;
     }
 
-    public function withIsActive(bool $isActive) : CategoryBuilder
+    public function withIsActive(bool $isActive): CategoryBuilder
     {
         $builder = clone $this;
         $builder->category->setIsActive($isActive);
@@ -152,7 +152,11 @@ class CategoryBuilder
         $this->category = clone $this->category;
     }
 
-    public function build() : CategoryInterface
+    /**
+     * @return CategoryInterface
+     * @throws \Exception
+     */
+    public function build(): CategoryInterface
     {
         $builder = clone $this;
         if (!$builder->category->getData('url_key')) {

--- a/src/Catalog/CategoryFixture.php
+++ b/src/Catalog/CategoryFixture.php
@@ -25,12 +25,12 @@ class CategoryFixture
         $this->category = $category;
     }
 
-    public function getId() : int
+    public function getId(): int
     {
         return $this->category->getId();
     }
 
-    public function getUrlKey() : string
+    public function getUrlKey(): string
     {
         /** @var Category $category */
         $category = $this->category;

--- a/src/Catalog/CategoryFixtureRollback.php
+++ b/src/Catalog/CategoryFixtureRollback.php
@@ -3,8 +3,10 @@
 namespace TddWizard\Fixtures\Catalog;
 
 use Magento\Catalog\Api\CategoryRepositoryInterface;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\Framework\Registry;
+use Magento\TestFramework\Helper\Bootstrap;
 
 class CategoryFixtureRollback
 {
@@ -12,6 +14,7 @@ class CategoryFixtureRollback
      * @var Registry
      */
     private $registry;
+
     /**
      * @var CategoryRepositoryInterface
      */
@@ -23,10 +26,10 @@ class CategoryFixtureRollback
         $this->categoryRepository = $categoryRepository;
     }
 
-    public static function create(ObjectManagerInterface $objectManager = null)
+    public static function create(ObjectManagerInterface $objectManager = null): CategoryFixtureRollback
     {
         if ($objectManager === null) {
-            $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+            $objectManager = Bootstrap::getObjectManager();
         }
         return new self(
             $objectManager->get(Registry::class),
@@ -34,7 +37,11 @@ class CategoryFixtureRollback
         );
     }
 
-    public function execute(CategoryFixture ...$categoryFixtures)
+    /**
+     * @param CategoryFixture ...$categoryFixtures
+     * @throws LocalizedException
+     */
+    public function execute(CategoryFixture ...$categoryFixtures): void
     {
         $this->registry->unregister('isSecureArea');
         $this->registry->register('isSecureArea', true);

--- a/src/Catalog/FulltextIndex.php
+++ b/src/Catalog/FulltextIndex.php
@@ -25,16 +25,21 @@ class FulltextIndex
         $this->indexerFactory = $indexerFactory;
     }
 
-    public static function ensureTablesAreCreated()
+    /**
+     * @throws \Throwable
+     */
+    public static function ensureTablesAreCreated(): void
     {
         if (!self::$created) {
             (new self(Bootstrap::getObjectManager()->create(IndexerFactory::class)))->reindex();
         }
     }
 
-    public function reindex()
+    /**
+     * @throws \Throwable
+     */
+    public function reindex(): void
     {
-        /** @var \Magento\Indexer\Model\Indexer $indexer */
         $indexer = $this->indexerFactory->create();
         $indexer->load('catalogsearch_fulltext');
         $indexer->reindexAll();

--- a/src/Catalog/IndexFailed.php
+++ b/src/Catalog/IndexFailed.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace TddWizard\Fixtures\Catalog;
@@ -23,7 +24,9 @@ Or set the fulltext indexer to "scheduled" before the transaction with:
  */ 
 
 TXT
-            , 0, $previous
+            ,
+            0,
+            $previous
         );
     }
 }

--- a/src/Catalog/ProductBuilder.php
+++ b/src/Catalog/ProductBuilder.php
@@ -3,7 +3,6 @@
 namespace TddWizard\Fixtures\Catalog;
 
 use Magento\Catalog\Api\Data\ProductInterface;
-use Magento\Catalog\Api\Data\ProductWebsiteLinkInterface;
 use Magento\Catalog\Api\Data\ProductWebsiteLinkInterfaceFactory;
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Api\ProductWebsiteLinkRepositoryInterface;
@@ -14,6 +13,7 @@ use Magento\CatalogInventory\Api\Data\StockItemInterface;
 use Magento\CatalogInventory\Api\StockItemRepositoryInterface;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\Indexer\Model\IndexerFactory;
+use Magento\TestFramework\Helper\Bootstrap;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -22,41 +22,49 @@ use Magento\Indexer\Model\IndexerFactory;
 class ProductBuilder
 {
     /**
-     * @var ProductInterface
-     */
-    protected $product;
-    /**
      * @var ProductRepositoryInterface
      */
     private $productRepository;
-    /**
-     * @var mixed[][]
-     */
-    private $storeSpecificValues = [];
-    /**
-     * @var int[]
-     */
-    private $websiteIds = [];
-    /**
-     * @var int[]
-     */
-    private $categoryIds = [];
-    /**
-     * @var ProductWebsiteLinkRepositoryInterface
-     */
-    private $websiteLinkRepository;
+
     /**
      * @var StockItemRepositoryInterface
      */
     private $stockItemRepository;
+
+    /**
+     * @var ProductWebsiteLinkRepositoryInterface
+     */
+    private $websiteLinkRepository;
+
     /**
      * @var ProductWebsiteLinkInterfaceFactory
      */
     private $websiteLinkFactory;
+
     /**
      * @var IndexerFactory
      */
     private $indexerFactory;
+
+    /**
+     * @var ProductInterface|Product
+     */
+    protected $product;
+
+    /**
+     * @var int[]
+     */
+    private $websiteIds;
+
+    /**
+     * @var mixed[][]
+     */
+    private $storeSpecificValues;
+
+    /**
+     * @var int[]
+     */
+    private $categoryIds = [];
 
     public function __construct(
         ProductRepositoryInterface $productRepository,
@@ -83,30 +91,32 @@ class ProductBuilder
         $this->product = clone $this->product;
     }
 
-    public static function aSimpleProduct(ObjectManagerInterface $objectManager = null) : ProductBuilder
+    public static function aSimpleProduct(ObjectManagerInterface $objectManager = null): ProductBuilder
     {
         if ($objectManager === null) {
-            $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+            $objectManager = Bootstrap::getObjectManager();
         }
-        /** @var ProductInterface $product */
+        /** @var ProductInterface|Product $product */
         $product = $objectManager->create(ProductInterface::class);
 
-        $product->setTypeId(\Magento\Catalog\Model\Product\Type::TYPE_SIMPLE)
-            ->setAttributeSetId(4)
-            ->setName('Simple Product')
-            ->setPrice(10)
-            ->setVisibility(Visibility::VISIBILITY_BOTH)
-            ->setStatus(Status::STATUS_ENABLED);
-        $product->addData([
-            'tax_class_id' => 1,
-            'description' => 'Description',
-        ]);
+        $product->setTypeId(Product\Type::TYPE_SIMPLE)
+                ->setAttributeSetId(4)
+                ->setName('Simple Product')
+                ->setPrice(10)
+                ->setVisibility(Visibility::VISIBILITY_BOTH)
+                ->setStatus(Status::STATUS_ENABLED);
+        $product->addData(
+            [
+                'tax_class_id' => 1,
+                'description' => 'Description',
+            ]
+        );
         /** @var StockItemInterface $stockItem */
         $stockItem = $objectManager->create(StockItemInterface::class);
         $stockItem->setManageStock(true)
-            ->setQty(100)
-            ->setIsQtyDecimal(false)
-            ->setIsInStock(true);
+                  ->setQty(100)
+                  ->setIsQtyDecimal(false)
+                  ->setIsInStock(true);
         $product->setExtensionAttributes(
             $product->getExtensionAttributes()->setStockItem($stockItem)
         );
@@ -123,7 +133,7 @@ class ProductBuilder
         );
     }
 
-    public function withData(array $data) : ProductBuilder
+    public function withData(array $data): ProductBuilder
     {
         $builder = clone $this;
 
@@ -132,14 +142,14 @@ class ProductBuilder
         return $builder;
     }
 
-    public function withSku(string $sku) : ProductBuilder
+    public function withSku(string $sku): ProductBuilder
     {
         $builder = clone $this;
         $builder->product->setSku($sku);
         return $builder;
     }
 
-    public function withName(string $name, $storeId = null) : ProductBuilder
+    public function withName(string $name, $storeId = null): ProductBuilder
     {
         $builder = clone $this;
         if ($storeId) {
@@ -156,7 +166,7 @@ class ProductBuilder
      *                          Attention: Status is configured per website, will affect all stores of the same website
      * @return ProductBuilder
      */
-    public function withStatus(int $status, $storeId = null) : ProductBuilder
+    public function withStatus(int $status, $storeId = null): ProductBuilder
     {
         $builder = clone $this;
         if ($storeId) {
@@ -167,7 +177,7 @@ class ProductBuilder
         return $builder;
     }
 
-    public function withVisibility(int $visibility, $storeId = null) : ProductBuilder
+    public function withVisibility(int $visibility, $storeId = null): ProductBuilder
     {
         $builder = clone $this;
         if ($storeId) {
@@ -178,56 +188,56 @@ class ProductBuilder
         return $builder;
     }
 
-    public function withWebsiteIds(array $websiteIds) : ProductBuilder
+    public function withWebsiteIds(array $websiteIds): ProductBuilder
     {
         $builder = clone $this;
         $builder->websiteIds = $websiteIds;
         return $builder;
     }
 
-    public function withCategoryIds(array $categoryIds) : ProductBuilder
+    public function withCategoryIds(array $categoryIds): ProductBuilder
     {
         $builder = clone $this;
         $builder->categoryIds = $categoryIds;
         return $builder;
     }
 
-    public function withPrice(float $price) : ProductBuilder
+    public function withPrice(float $price): ProductBuilder
     {
         $builder = clone $this;
         $builder->product->setPrice($price);
         return $builder;
     }
 
-    public function withTaxClassId($taxClassId) : ProductBuilder
+    public function withTaxClassId($taxClassId): ProductBuilder
     {
         $builder = clone $this;
         $builder->product->setData('tax_class_id', $taxClassId);
         return $builder;
     }
 
-    public function withIsInStock(bool $inStock) : ProductBuilder
+    public function withIsInStock(bool $inStock): ProductBuilder
     {
         $builder = clone $this;
         $builder->product->getExtensionAttributes()->getStockItem()->setIsInStock($inStock);
         return $builder;
     }
 
-    public function withStockQty($qty) : ProductBuilder
+    public function withStockQty($qty): ProductBuilder
     {
         $builder = clone $this;
         $builder->product->getExtensionAttributes()->getStockItem()->setQty($qty);
         return $builder;
     }
 
-    public function withWeight($weight) : ProductBuilder
+    public function withWeight($weight): ProductBuilder
     {
         $builder = clone $this;
         $builder->product->setWeight($weight);
         return $builder;
     }
 
-    public function withCustomAttributes(array $values, $storeId = null) : ProductBuilder
+    public function withCustomAttributes(array $values, $storeId = null): ProductBuilder
     {
         $builder = clone $this;
         foreach ($values as $code => $value) {
@@ -240,7 +250,11 @@ class ProductBuilder
         return $builder;
     }
 
-    public function build() : ProductInterface
+    /**
+     * @return ProductInterface
+     * @throws \Exception
+     */
+    public function build(): ProductInterface
     {
         try {
             $product = $this->createProduct();
@@ -248,14 +262,17 @@ class ProductBuilder
             return $product;
         } catch (\Exception $e) {
             $e->getPrevious();
-            if ($this->isTransactionException($e) || $this->isTransactionException($e->getPrevious()))
-            {
+            if ($this->isTransactionException($e) || $this->isTransactionException($e->getPrevious())) {
                 throw IndexFailed::becauseInitiallyTriggeredInTransaction($e);
             }
             throw $e;
         }
     }
 
+    /**
+     * @return ProductInterface
+     * @throws \Exception
+     */
     private function createProduct(): ProductInterface
     {
         $builder = clone $this;
@@ -263,10 +280,9 @@ class ProductBuilder
             $builder->product->setSku(sha1(uniqid('', true)));
         }
         $builder->product->setCustomAttribute('url_key', $builder->product->getSku());
-        $builder->product->setCategoryIds($builder->categoryIds);
+        $builder->product->setData('category_ids', $builder->categoryIds);
         $product = $builder->productRepository->save($builder->product);
         foreach ($builder->websiteIds as $websiteId) {
-            /** @var ProductWebsiteLinkInterface $websiteLink */
             $websiteLink = $builder->websiteLinkFactory->create();
             $websiteLink->setWebsiteId($websiteId)->setSku($product->getSku());
             $builder->websiteLinkRepository->save($websiteLink);
@@ -281,7 +297,7 @@ class ProductBuilder
         return $product;
     }
 
-    private function isTransactionException($exception)
+    private function isTransactionException($exception): bool
     {
         if ($exception === null) {
             return false;

--- a/src/Catalog/ProductFixture.php
+++ b/src/Catalog/ProductFixture.php
@@ -16,12 +16,12 @@ class ProductFixture
         $this->product = $product;
     }
 
-    public function getId() : int
+    public function getId(): int
     {
         return $this->product->getId();
     }
 
-    public function getSku() : string
+    public function getSku(): string
     {
         return $this->product->getSku();
     }

--- a/src/Catalog/ProductFixtureRollback.php
+++ b/src/Catalog/ProductFixtureRollback.php
@@ -3,8 +3,10 @@
 namespace TddWizard\Fixtures\Catalog;
 
 use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\Framework\Registry;
+use Magento\TestFramework\Helper\Bootstrap;
 
 class ProductFixtureRollback
 {
@@ -12,6 +14,7 @@ class ProductFixtureRollback
      * @var Registry
      */
     private $registry;
+
     /**
      * @var ProductRepositoryInterface
      */
@@ -23,10 +26,10 @@ class ProductFixtureRollback
         $this->productRepository = $productRepository;
     }
 
-    public static function create(ObjectManagerInterface $objectManager = null)
+    public static function create(ObjectManagerInterface $objectManager = null): ProductFixtureRollback
     {
         if ($objectManager === null) {
-            $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+            $objectManager = Bootstrap::getObjectManager();
         }
         return new self(
             $objectManager->get(Registry::class),
@@ -34,7 +37,11 @@ class ProductFixtureRollback
         );
     }
 
-    public function execute(ProductFixture ...$productFixtures)
+    /**
+     * @param ProductFixture ...$productFixtures
+     * @throws LocalizedException
+     */
+    public function execute(ProductFixture ...$productFixtures): void
     {
         $this->registry->unregister('isSecureArea');
         $this->registry->register('isSecureArea', true);

--- a/src/Checkout/CustomerCheckout.php
+++ b/src/Checkout/CustomerCheckout.php
@@ -18,34 +18,42 @@ class CustomerCheckout
      * @var AddressRepositoryInterface
      */
     private $addressRepository;
+
     /**
      * @var CartRepositoryInterface
      */
     private $quoteRepository;
+
     /**
      * @var QuoteManagement
      */
     private $quoteManagement;
+
     /**
      * @var PaymentConfig
      */
     private $paymentConfig;
+
     /**
      * @var Cart
      */
     private $cart;
+
     /**
      * @var int|null
      */
     private $customerShippingAddressId;
+
     /**
      * @var int|null
      */
     private $customerBillingAddressId;
+
     /**
      * @var string|null
      */
     private $shippingMethodCode;
+
     /**
      * @var string|null
      */
@@ -74,7 +82,7 @@ class CustomerCheckout
         $this->paymentMethodCode = $paymentMethodCode;
     }
 
-    public static function fromCart(Cart $cart, ObjectManagerInterface $objectManager = null) : CustomerCheckout
+    public static function fromCart(Cart $cart, ObjectManagerInterface $objectManager = null): CustomerCheckout
     {
         if ($objectManager === null) {
             $objectManager = Bootstrap::getObjectManager();
@@ -88,28 +96,28 @@ class CustomerCheckout
         );
     }
 
-    public function withCustomerBillingAddressId(int $addressId) : CustomerCheckout
+    public function withCustomerBillingAddressId(int $addressId): CustomerCheckout
     {
         $checkout = clone $this;
         $checkout->customerBillingAddressId = $addressId;
         return $checkout;
     }
 
-    public function withCustomerShippingAddressId(int $addressId) : CustomerCheckout
+    public function withCustomerShippingAddressId(int $addressId): CustomerCheckout
     {
         $checkout = clone $this;
         $checkout->customerShippingAddressId = $addressId;
         return $checkout;
     }
 
-    public function withShippingMethodCode(string $code) : CustomerCheckout
+    public function withShippingMethodCode(string $code): CustomerCheckout
     {
         $checkout = clone $this;
         $checkout->shippingMethodCode = $code;
         return $checkout;
     }
 
-    public function withPaymentMethodCode(string $code) : CustomerCheckout
+    public function withPaymentMethodCode(string $code): CustomerCheckout
     {
         $checkout = clone $this;
         $checkout->paymentMethodCode = $code;
@@ -119,17 +127,16 @@ class CustomerCheckout
     /**
      * @return int Customer shipping address as configured or try default shipping address
      */
-    private function getCustomerShippingAddressId() : int
+    private function getCustomerShippingAddressId(): int
     {
         return $this->customerShippingAddressId
             ?? $this->cart->getCustomerSession()->getCustomer()->getDefaultShippingAddress()->getId();
     }
 
-
     /**
      * @return int Customer billing address as configured or try default billing address
      */
-    private function getCustomerBillingAddressId() : int
+    private function getCustomerBillingAddressId(): int
     {
         return $this->customerBillingAddressId
             ?? $this->cart->getCustomerSession()->getCustomer()->getDefaultBillingAddress()->getId();
@@ -138,7 +145,7 @@ class CustomerCheckout
     /**
      * @return string Shipping method code as configured, or try first available rate
      */
-    private function getShippingMethodCode() : string
+    private function getShippingMethodCode(): string
     {
         return $this->shippingMethodCode
             ?? $this->cart->getQuote()->getShippingAddress()->getAllShippingRates()[0]->getCode();
@@ -147,12 +154,16 @@ class CustomerCheckout
     /**
      * @return string Payment method code as configured, or try first available method
      */
-    private function getPaymentMethodCode() : string
+    private function getPaymentMethodCode(): string
     {
         return $this->paymentMethodCode ?? array_values($this->paymentConfig->getActiveMethods())[0]->getCode();
     }
 
-    public function placeOrder() : OrderInterface
+    /**
+     * @return OrderInterface
+     * @throws \Exception
+     */
+    public function placeOrder(): OrderInterface
     {
         $this->saveBilling();
         $this->saveShipping();
@@ -166,7 +177,10 @@ class CustomerCheckout
         return $order;
     }
 
-    private function saveBilling()
+    /**
+     * @throws \Exception
+     */
+    private function saveBilling(): void
     {
         $billingAddress = $this->cart->getQuote()->getBillingAddress();
         $billingAddress->importCustomerAddressData(
@@ -175,7 +189,10 @@ class CustomerCheckout
         $billingAddress->save();
     }
 
-    private function saveShipping()
+    /**
+     * @throws \Exception
+     */
+    private function saveShipping(): void
     {
         $shippingAddress = $this->cart->getQuote()->getShippingAddress();
         $shippingAddress->importCustomerAddressData(
@@ -187,7 +204,10 @@ class CustomerCheckout
         $shippingAddress->save();
     }
 
-    private function savePayment()
+    /**
+     * @throws \Exception
+     */
+    private function savePayment(): void
     {
         $payment = $this->cart->getQuote()->getPayment();
         $payment->setMethod($this->getPaymentMethodCode());

--- a/src/Customer/AddressBuilder.php
+++ b/src/Customer/AddressBuilder.php
@@ -5,8 +5,10 @@ namespace TddWizard\Fixtures\Customer;
 use Faker\Factory as FakerFactory;
 use Magento\Customer\Api\AddressRepositoryInterface;
 use Magento\Customer\Api\Data\AddressInterface;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\Directory\Model\Region;
+use Magento\TestFramework\Helper\Bootstrap;
 
 /**
  * Builder to be used by fixtures
@@ -39,7 +41,7 @@ class AddressBuilder
         string $locale = 'de_DE'
     ): AddressBuilder {
         if ($objectManager === null) {
-            $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+            $objectManager = Bootstrap::getObjectManager();
         }
 
         $faker = FakerFactory::create($locale);
@@ -69,91 +71,91 @@ class AddressBuilder
         return new self($objectManager->create(AddressRepositoryInterface::class), $address);
     }
 
-    public function asDefaultShipping() : AddressBuilder
+    public function asDefaultShipping(): AddressBuilder
     {
         $builder = clone $this;
         $builder->address->setIsDefaultShipping(true);
         return $builder;
     }
 
-    public function asDefaultBilling() : AddressBuilder
+    public function asDefaultBilling(): AddressBuilder
     {
         $builder = clone $this;
         $builder->address->setIsDefaultBilling(true);
         return $builder;
     }
 
-    public function withPrefix($prefix) : AddressBuilder
+    public function withPrefix($prefix): AddressBuilder
     {
         $builder = clone $this;
         $builder->address->setPrefix($prefix);
         return $builder;
     }
 
-    public function withFirstname($firstname) : AddressBuilder
+    public function withFirstname($firstname): AddressBuilder
     {
         $builder = clone $this;
         $builder->address->setFirstname($firstname);
         return $builder;
     }
 
-    public function withLastname($lastname) : AddressBuilder
+    public function withLastname($lastname): AddressBuilder
     {
         $builder = clone $this;
         $builder->address->setLastname($lastname);
         return $builder;
     }
 
-    public function withStreet($street) : AddressBuilder
+    public function withStreet($street): AddressBuilder
     {
         $builder = clone $this;
-        $builder->address->setStreet((array) $street);
+        $builder->address->setStreet((array)$street);
         return $builder;
     }
 
-    public function withCompany($company) : AddressBuilder
+    public function withCompany($company): AddressBuilder
     {
         $builder = clone $this;
         $builder->address->setCompany($company);
         return $builder;
     }
 
-    public function withTelephone($telephone) : AddressBuilder
+    public function withTelephone($telephone): AddressBuilder
     {
         $builder = clone $this;
         $builder->address->setTelephone($telephone);
         return $builder;
     }
 
-    public function withPostcode($postcode) : AddressBuilder
+    public function withPostcode($postcode): AddressBuilder
     {
         $builder = clone $this;
         $builder->address->setPostcode($postcode);
         return $builder;
     }
 
-    public function withCity($city) : AddressBuilder
+    public function withCity($city): AddressBuilder
     {
         $builder = clone $this;
         $builder->address->setCity($city);
         return $builder;
     }
 
-    public function withCountryId($countryId) : AddressBuilder
+    public function withCountryId($countryId): AddressBuilder
     {
         $builder = clone $this;
         $builder->address->setCountryId($countryId);
         return $builder;
     }
 
-    public function withRegionId($regionId) : AddressBuilder
+    public function withRegionId($regionId): AddressBuilder
     {
         $builder = clone $this;
         $builder->address->setRegionId($regionId);
         return $builder;
     }
 
-    public function withCustomAttributes(array $values) : AddressBuilder
+    public function withCustomAttributes(array $values): AddressBuilder
     {
         $builder = clone $this;
         foreach ($values as $code => $value) {
@@ -162,12 +164,16 @@ class AddressBuilder
         return $builder;
     }
 
-    public function build() : AddressInterface
+    /**
+     * @return AddressInterface
+     * @throws LocalizedException
+     */
+    public function build(): AddressInterface
     {
         return $this->addressRepository->save($this->address);
     }
 
-    public function buildWithoutSave() : AddressInterface
+    public function buildWithoutSave(): AddressInterface
     {
         return clone $this->address;
     }

--- a/src/Customer/CustomerBuilder.php
+++ b/src/Customer/CustomerBuilder.php
@@ -4,8 +4,10 @@ namespace TddWizard\Fixtures\Customer;
 
 use Magento\Customer\Api\CustomerRepositoryInterface;
 use Magento\Customer\Api\Data\CustomerInterface;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\Framework\Encryption\EncryptorInterface as Encryptor;
+use Magento\TestFramework\Helper\Bootstrap;
 
 /**
  * Builder to be used by fixtures
@@ -16,18 +18,22 @@ class CustomerBuilder
      * @var CustomerInterface
      */
     private $customer;
+
     /**
      * @var string
      */
     private $password;
+
     /**
      * @var CustomerRepositoryInterface
      */
     private $customerRepository;
+
     /**
      * @var AddressBuilder[]
      */
-    private $addressBuilders = [];
+    private $addressBuilders;
+
     /**
      * @var Encryptor
      */
@@ -52,10 +58,10 @@ class CustomerBuilder
         $this->customer = clone $this->customer;
     }
 
-    public static function aCustomer(ObjectManagerInterface $objectManager = null) : CustomerBuilder
+    public static function aCustomer(ObjectManagerInterface $objectManager = null): CustomerBuilder
     {
         if ($objectManager === null) {
-            $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+            $objectManager = Bootstrap::getObjectManager();
         }
         /** @var CustomerInterface $customer */
         $customer = $objectManager->create(CustomerInterface::class);
@@ -78,92 +84,91 @@ class CustomerBuilder
         );
     }
 
-    public function withAddresses(AddressBuilder ...$addressBuilders) : CustomerBuilder
+    public function withAddresses(AddressBuilder ...$addressBuilders): CustomerBuilder
     {
         $builder = clone $this;
         $builder->addressBuilders = $addressBuilders;
         return $builder;
     }
 
-    public function withEmail(string $email) : CustomerBuilder
+    public function withEmail(string $email): CustomerBuilder
     {
         $builder = clone $this;
         $builder->customer->setEmail($email);
         return $builder;
     }
 
-    public function withGroupId($groupId) : CustomerBuilder
+    public function withGroupId($groupId): CustomerBuilder
     {
         $builder = clone $this;
         $builder->customer->setGroupId($groupId);
         return $builder;
     }
 
-    public function withStoreId($storeId) : CustomerBuilder
+    public function withStoreId($storeId): CustomerBuilder
     {
         $builder = clone $this;
         $builder->customer->setStoreId($storeId);
         return $builder;
     }
 
-    public function withWebsiteId($websiteId) : CustomerBuilder
+    public function withWebsiteId($websiteId): CustomerBuilder
     {
         $builder = clone $this;
         $builder->customer->setWebsiteId($websiteId);
         return $builder;
     }
 
-    public function withPrefix($prefix) : CustomerBuilder
+    public function withPrefix($prefix): CustomerBuilder
     {
         $builder = clone $this;
         $builder->customer->setPrefix($prefix);
         return $builder;
     }
 
-    public function withFirstname($firstname) : CustomerBuilder
+    public function withFirstname($firstname): CustomerBuilder
     {
         $builder = clone $this;
         $builder->customer->setFirstname($firstname);
         return $builder;
     }
 
-    public function withMiddlename($middlename) : CustomerBuilder
+    public function withMiddlename($middlename): CustomerBuilder
     {
         $builder = clone $this;
         $builder->customer->setMiddlename($middlename);
         return $builder;
     }
 
-    public function withLastname($lastname) : CustomerBuilder
+    public function withLastname($lastname): CustomerBuilder
     {
         $builder = clone $this;
         $builder->customer->setLastname($lastname);
         return $builder;
     }
 
-    public function withSuffix($suffix) : CustomerBuilder
+    public function withSuffix($suffix): CustomerBuilder
     {
         $builder = clone $this;
         $builder->customer->setSuffix($suffix);
         return $builder;
     }
 
-    public function withTaxvat($taxvat) : CustomerBuilder
+    public function withTaxvat($taxvat): CustomerBuilder
     {
         $builder = clone $this;
         $builder->customer->setTaxvat($taxvat);
         return $builder;
     }
 
-    public function withDob($dob) : CustomerBuilder
+    public function withDob($dob): CustomerBuilder
     {
         $builder = clone $this;
         $builder->customer->setDob($dob);
         return $builder;
     }
 
-
-    public function withCustomAttributes(array $values) : CustomerBuilder
+    public function withCustomAttributes(array $values): CustomerBuilder
     {
         $builder = clone $this;
         foreach ($values as $code => $value) {
@@ -172,14 +177,18 @@ class CustomerBuilder
         return $builder;
     }
 
-    public function withConfirmation(string $confirmation) : CustomerBuilder
+    public function withConfirmation(string $confirmation): CustomerBuilder
     {
         $builder = clone $this;
         $builder->customer->setConfirmation($confirmation);
         return $builder;
     }
 
-    public function build() : CustomerInterface
+    /**
+     * @return CustomerInterface
+     * @throws LocalizedException
+     */
+    public function build(): CustomerInterface
     {
         $builder = clone $this;
         if (!$builder->customer->getEmail()) {
@@ -203,6 +212,9 @@ class CustomerBuilder
 
     /**
      * @SuppressWarnings(PHPMD.UnusedPrivateMethod) False positive: the method is used in build() on the cloned builder
+     *
+     * @return CustomerInterface
+     * @throws LocalizedException
      */
     private function saveNewCustomer(): CustomerInterface
     {

--- a/src/Customer/CustomerFixture.php
+++ b/src/Customer/CustomerFixture.php
@@ -5,7 +5,6 @@ namespace TddWizard\Fixtures\Customer;
 use Magento\Customer\Api\Data\AddressInterface;
 use Magento\Customer\Api\Data\CustomerInterface;
 use Magento\Customer\Model\Session;
-use Magento\Framework\ObjectManagerInterface;
 use Magento\TestFramework\Helper\Bootstrap;
 
 /**
@@ -23,22 +22,22 @@ class CustomerFixture
         $this->customer = $customer;
     }
 
-    public function getDefaultShippingAddressId() : int
+    public function getDefaultShippingAddressId(): int
     {
         return $this->customer->getDefaultShipping();
     }
 
-    public function getDefaultBillingAddressId() : int
+    public function getDefaultBillingAddressId(): int
     {
         return $this->customer->getDefaultBilling();
     }
 
-    public function getOtherAddressId() : int
+    public function getOtherAddressId(): int
     {
         return $this->getNonDefaultAddressIds()[0];
     }
 
-    public function getNonDefaultAddressIds() : array
+    public function getNonDefaultAddressIds(): array
     {
         return array_values(
             array_diff(
@@ -58,22 +57,22 @@ class CustomerFixture
         );
     }
 
-    public function getId() : int
+    public function getId(): int
     {
         return $this->customer->getId();
     }
 
-    public function getConfirmation() : string
+    public function getConfirmation(): string
     {
         return $this->customer->getConfirmation();
     }
 
-    public function getEmail() : string
+    public function getEmail(): string
     {
         return $this->customer->getEmail();
     }
 
-    public function login(Session $session = null)
+    public function login(Session $session = null): void
     {
         if ($session === null) {
             $objectManager = Bootstrap::getObjectManager();
@@ -83,7 +82,7 @@ class CustomerFixture
         $session->setCustomerId($this->getId());
     }
 
-    public function logout(Session $session = null)
+    public function logout(Session $session = null): void
     {
         if ($session === null) {
             $objectManager = Bootstrap::getObjectManager();

--- a/src/Customer/CustomerFixtureRollback.php
+++ b/src/Customer/CustomerFixtureRollback.php
@@ -3,8 +3,10 @@
 namespace TddWizard\Fixtures\Customer;
 
 use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\Framework\Registry;
+use Magento\TestFramework\Helper\Bootstrap;
 
 class CustomerFixtureRollback
 {
@@ -23,10 +25,10 @@ class CustomerFixtureRollback
         $this->customerRepository = $customerRepository;
     }
 
-    public static function create(ObjectManagerInterface $objectManager = null)
+    public static function create(ObjectManagerInterface $objectManager = null): CustomerFixtureRollback
     {
         if ($objectManager === null) {
-            $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+            $objectManager = Bootstrap::getObjectManager();
         }
         return new self(
             $objectManager->get(Registry::class),
@@ -34,7 +36,11 @@ class CustomerFixtureRollback
         );
     }
 
-    public function execute(CustomerFixture ...$customerFixtures)
+    /**
+     * @param CustomerFixture ...$customerFixtures
+     * @throws LocalizedException
+     */
+    public function execute(CustomerFixture ...$customerFixtures): void
     {
         $this->registry->unregister('isSecureArea');
         $this->registry->register('isSecureArea', true);

--- a/src/Sales/OrderFixtureRollback.php
+++ b/src/Sales/OrderFixtureRollback.php
@@ -10,6 +10,7 @@ use Magento\Framework\ObjectManagerInterface;
 use Magento\Framework\Registry;
 use Magento\Sales\Api\Data\OrderItemInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\TestFramework\Helper\Bootstrap;
 
 class OrderFixtureRollback
 {
@@ -45,10 +46,10 @@ class OrderFixtureRollback
         $this->productRepository = $productRepository;
     }
 
-    public static function create(ObjectManagerInterface $objectManager = null)
+    public static function create(ObjectManagerInterface $objectManager = null): OrderFixtureRollback
     {
         if ($objectManager === null) {
-            $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+            $objectManager = Bootstrap::getObjectManager();
         }
 
         return new self(
@@ -66,7 +67,7 @@ class OrderFixtureRollback
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    public function execute(OrderFixture ...$orderFixtures)
+    public function execute(OrderFixture ...$orderFixtures): void
     {
         $this->registry->unregister('isSecureArea');
         $this->registry->register('isSecureArea', true);

--- a/tests/Catalog/CategoryBuilderTest.php
+++ b/tests/Catalog/CategoryBuilderTest.php
@@ -4,7 +4,6 @@ namespace TddWizard\Fixtures\Catalog;
 
 use Magento\Catalog\Api\CategoryRepositoryInterface;
 use Magento\Catalog\Model\Category;
-use Magento\Framework\ObjectManagerInterface;
 use Magento\TestFramework\Helper\Bootstrap;
 use PHPUnit\Framework\TestCase;
 
@@ -15,11 +14,6 @@ use PHPUnit\Framework\TestCase;
  */
 class CategoryBuilderTest extends TestCase
 {
-    /**
-     * @var ObjectManagerInterface
-     */
-    private $objectManager;
-
     /**
      * @var CategoryFixture[]
      */
@@ -35,15 +29,14 @@ class CategoryBuilderTest extends TestCase
      */
     private $categoryRepository;
 
-    protected function setUp()
+    protected function setUp(): void
     {
-        $this->objectManager = Bootstrap::getObjectManager();
-        $this->categoryRepository = $this->objectManager->create(CategoryRepositoryInterface::class);
+        $this->categoryRepository = Bootstrap::getObjectManager()->create(CategoryRepositoryInterface::class);
         $this->categories = [];
         $this->products = [];
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if (!empty($this->categories)) {
             foreach ($this->categories as $product) {
@@ -66,10 +59,18 @@ class CategoryBuilderTest extends TestCase
 
         /** @var Category $category */
         $category = $this->categoryRepository->get($categoryFixture->getId());
-        $this->assertEquals('Top Level Category', $category->getName(), 'Category name');
-        $this->assertContains(0, $category->getStoreIds(), 'Assigned admin store id');
-        $this->assertContains(1, $category->getStoreIds(), 'Assigned default store id');
-        $this->assertEquals('1/2/' . $categoryFixture->getId(), $category->getPath(), 'Category path');
+
+        // store ids are mixed type, normalize first for strict type checking
+        $storeIds = array_map('strval', $category->getStoreIds());
+
+        $this->assertEquals('Top Level Category', $category->getName(), 'Category name does not match expected value.');
+        $this->assertContains('0', $storeIds, 'Admin store ID is not assigned.');
+        $this->assertContains('1', $storeIds, 'Default store ID is not assigned.');
+        $this->assertEquals(
+            '1/2/' . $categoryFixture->getId(),
+            $category->getPath(),
+            'Category path does not match expected value.'
+        );
     }
 
     public function testDefaultChildCategory()
@@ -84,13 +85,17 @@ class CategoryBuilderTest extends TestCase
 
         /** @var Category $category */
         $category = $this->categoryRepository->get($childCategoryFixture->getId());
-        $this->assertEquals('Child Category', $category->getName(), 'Category name');
-        $this->assertContains(0, $category->getStoreIds(), 'Assigned admin store id');
-        $this->assertContains(1, $category->getStoreIds(), 'Assigned default store id');
+
+        // store ids are mixed type, normalize first for strict type checking
+        $storeIds = array_map('strval', $category->getStoreIds());
+
+        $this->assertEquals('Child Category', $category->getName(), 'Category name does not match expected value.');
+        $this->assertContains('0', $storeIds, 'Admin store ID is not assigned.');
+        $this->assertContains('1', $storeIds, 'Default store ID is not assigned.');
         $this->assertEquals(
             '1/2/' . $parentCategoryFixture->getId() . '/' . $childCategoryFixture->getId(),
             $category->getPath(),
-            'Category path'
+            'Category path does not match expected value.'
         );
     }
 

--- a/tests/Catalog/ProductBuilderTest.php
+++ b/tests/Catalog/ProductBuilderTest.php
@@ -33,14 +33,14 @@ class ProductBuilderTest extends TestCase
      */
     private $productRepository;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->objectManager = Bootstrap::getObjectManager();
         $this->productRepository = $this->objectManager->create(ProductRepositoryInterface::class);
         $this->products = [];
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if (! empty($this->products)) {
             foreach ($this->products as $product) {
@@ -172,7 +172,11 @@ class ProductBuilderTest extends TestCase
         /** @var Product $product */
         $productInStore = $this->productRepository->getById($productFixture->getId(), false, $secondStoreId);
         $this->assertEquals('Store Name', $productInStore->getName(), 'Store specific name');
-        $this->assertEquals(Status::STATUS_ENABLED, $productInStore->getStatus(), 'Store specific status should be enabled');
+        $this->assertEquals(
+            Status::STATUS_ENABLED,
+            $productInStore->getStatus(),
+            'Store specific status should be enabled'
+        );
         $this->assertEquals(
             Product\Visibility::VISIBILITY_IN_CATALOG,
             $productInStore->getVisibility(),

--- a/tests/Catalog/ProductFixtureRollbackTest.php
+++ b/tests/Catalog/ProductFixtureRollbackTest.php
@@ -19,7 +19,7 @@ class ProductFixtureRollbackTest extends TestCase
      */
     private $productRepository;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->productRepository = Bootstrap::getObjectManager()->create(ProductRepositoryInterface::class);
     }
@@ -53,5 +53,4 @@ class ProductFixtureRollbackTest extends TestCase
         $this->expectException(NoSuchEntityException::class);
         $this->productRepository->getById($otherProductFixture->getId());
     }
-
 }

--- a/tests/Checkout/CartBuilderTest.php
+++ b/tests/Checkout/CartBuilderTest.php
@@ -14,7 +14,7 @@ class CartBuilderTest extends TestCase
      */
     private $productFixture;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->productFixture = new ProductFixture(
             ProductBuilder::aSimpleProduct()->build()

--- a/tests/Checkout/CustomerCheckoutTest.php
+++ b/tests/Checkout/CustomerCheckoutTest.php
@@ -2,9 +2,6 @@
 
 namespace TddWizard\Fixtures\Checkout;
 
-use Magento\Catalog\Api\ProductRepositoryInterface;
-use Magento\TestFramework\Helper\Bootstrap;
-use Magento\TestFramework\ObjectManager;
 use PHPUnit\Framework\TestCase;
 use TddWizard\Fixtures\Catalog\ProductBuilder;
 use TddWizard\Fixtures\Catalog\ProductFixture;
@@ -28,19 +25,8 @@ class CustomerCheckoutTest extends TestCase
      */
     private $productFixture;
 
-    /**
-     * @var ObjectManager
-     */
-    private $objectManager;
-    /**
-     * @var ProductRepositoryInterface
-     */
-    private $productRepository;
-
-    protected function setUp()
+    protected function setUp(): void
     {
-        $this->objectManager = Bootstrap::getObjectManager();
-        $this->productRepository = $this->objectManager->create(ProductRepositoryInterface::class);
         $this->customerFixture = new CustomerFixture(
             CustomerBuilder::aCustomer()
                 ->withAddresses(
@@ -54,12 +40,11 @@ class CustomerCheckoutTest extends TestCase
                 ->build()
         );
     }
-    protected function tearDown()
+    protected function tearDown(): void
     {
         CustomerFixtureRollback::create()->execute($this->customerFixture);
         ProductFixtureRollback::create()->execute($this->productFixture);
     }
-
 
     /**
      * @magentoAppIsolation enabled

--- a/tests/Customer/CustomerBuilderTest.php
+++ b/tests/Customer/CustomerBuilderTest.php
@@ -3,6 +3,7 @@
 namespace TddWizard\Fixtures\Customer;
 
 use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\TestFramework\Helper\Bootstrap;
@@ -29,14 +30,14 @@ class CustomerBuilderTest extends TestCase
      */
     private $customerRepository;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->objectManager = Bootstrap::getObjectManager();
         $this->customerRepository = $this->objectManager->create(CustomerRepositoryInterface::class);
         $this->customers = [];
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if (! empty($this->customers)) {
             foreach ($this->customers as $customer) {
@@ -150,8 +151,7 @@ class CustomerBuilderTest extends TestCase
     }
 
     /**
-     * @throws \Magento\Framework\Exception\LocalizedException
-     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     * @throws LocalizedException
      */
     public function testLocalizedAddresses()
     {

--- a/tests/Customer/CustomerFixtureRollbackTest.php
+++ b/tests/Customer/CustomerFixtureRollbackTest.php
@@ -18,7 +18,7 @@ class CustomerFixtureRollbackTest extends TestCase
      */
     private $customerRepository;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->customerRepository = Bootstrap::getObjectManager()->create(CustomerRepositoryInterface::class);
     }

--- a/tests/Sales/CreditmemoBuilderTest.php
+++ b/tests/Sales/CreditmemoBuilderTest.php
@@ -2,6 +2,7 @@
 
 namespace TddWizard\Fixtures\Sales;
 
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Sales\Api\CreditmemoRepositoryInterface;
 use Magento\Sales\Api\Data\CreditmemoInterface;
 use Magento\Sales\Api\Data\OrderItemInterface;
@@ -26,7 +27,7 @@ class CreditmemoBuilderTest extends TestCase
      */
     private $creditmemoRepository;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -34,10 +35,9 @@ class CreditmemoBuilderTest extends TestCase
     }
 
     /**
-     * @throws \Magento\Framework\Exception\LocalizedException
-     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     * @throws LocalizedException
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         OrderFixtureRollback::create()->execute($this->orderFixture);
 

--- a/tests/Sales/InvoiceBuilderTest.php
+++ b/tests/Sales/InvoiceBuilderTest.php
@@ -2,6 +2,7 @@
 
 namespace TddWizard\Fixtures\Sales;
 
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Sales\Api\Data\InvoiceInterface;
 use Magento\Sales\Api\Data\OrderItemInterface;
 use Magento\Sales\Api\InvoiceRepositoryInterface;
@@ -26,7 +27,7 @@ class InvoiceBuilderTest extends TestCase
      */
     private $invoiceRepository;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -34,10 +35,9 @@ class InvoiceBuilderTest extends TestCase
     }
 
     /**
-     * @throws \Magento\Framework\Exception\LocalizedException
-     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     * @throws LocalizedException
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         OrderFixtureRollback::create()->execute($this->orderFixture);
 

--- a/tests/Sales/OrderBuilderTest.php
+++ b/tests/Sales/OrderBuilderTest.php
@@ -2,6 +2,7 @@
 
 namespace TddWizard\Fixtures\Sales;
 
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Magento\TestFramework\Helper\Bootstrap;
@@ -27,7 +28,7 @@ class OrderBuilderTest extends TestCase
      */
     private $orderRepository;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -35,10 +36,9 @@ class OrderBuilderTest extends TestCase
     }
 
     /**
-     * @throws \Magento\Framework\Exception\LocalizedException
-     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     * @throws LocalizedException
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         OrderFixtureRollback::create()->execute(...$this->orderFixtures);
 

--- a/tests/Sales/ShipmentBuilderTest.php
+++ b/tests/Sales/ShipmentBuilderTest.php
@@ -2,6 +2,7 @@
 
 namespace TddWizard\Fixtures\Sales;
 
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Sales\Api\Data\OrderItemInterface;
 use Magento\Sales\Api\Data\ShipmentInterface;
 use Magento\Sales\Api\Data\ShipmentTrackInterface;
@@ -27,7 +28,7 @@ class ShipmentBuilderTest extends TestCase
      */
     private $shipmentRepository;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -35,10 +36,9 @@ class ShipmentBuilderTest extends TestCase
     }
 
     /**
-     * @throws \Magento\Framework\Exception\LocalizedException
-     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     * @throws LocalizedException
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         OrderFixtureRollback::create()->execute($this->orderFixture);
 

--- a/tests/install-config-mysql.php
+++ b/tests/install-config-mysql.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * Copyright © 2016 Magento. All rights reserved.
- * See COPYING.txt for license details.
- */
 
 return [
     'db-host' => 'DB_HOST',
@@ -20,5 +16,4 @@ return [
     'amqp-port' => '',
     'amqp-user' => '',
     'amqp-password' => '',
-
 ];

--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -5,7 +5,7 @@
  */
 -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.5/phpunit.xsd"
          colors="true"
          bootstrap="./framework/bootstrap.php"
 >


### PR DESCRIPTION
This PR establishes compatibility with Magento 2.4 and drops compatibility with the now EOL'd Magento 2.2 (see also #38).

The main changes are:

* PHP version requirement updated
* Module version dependencies updated
* Return type declarations (`setUp`, `tearDown`) aligned with PHPUnit 9 base methods
* Test assertions refactored to low-level checks where there is no common candidate in PHPUnit 6 (M2.3) and PHPUnit 9 (M2.4)

I also took care of some inspection issues while I was there.