### PR TITLE
Add builder for product attributes that have options

### DIFF
--- a/src/Catalog/OptionBuilder.php
+++ b/src/Catalog/OptionBuilder.php
@@ -21,7 +21,7 @@ class OptionBuilder
     /**
      * @var AttributeOptionManagementInterface
      */
-    private $attributeOptionManagement;
+    private $optionManagement;
 
     /**
      * @var AttributeOption
@@ -41,18 +41,18 @@ class OptionBuilder
     /**
      * OptionBuilder constructor.
      *
-     * @param AttributeOptionManagementInterface $attributeOptionManagement
+     * @param AttributeOptionManagementInterface $optionManagement
      * @param AttributeOption $option
      * @param AttributeOptionLabelInterface $optionLabel
      * @param string $attributeCode
      */
     public function __construct(
-        AttributeOptionManagementInterface $attributeOptionManagement,
+        AttributeOptionManagementInterface $optionManagement,
         AttributeOption $option,
         AttributeOptionLabelInterface $optionLabel,
         string $attributeCode
     ) {
-        $this->attributeOptionManagement = $attributeOptionManagement;
+        $this->optionManagement = $optionManagement;
         $this->option = $option;
         $this->optionLabel = $optionLabel;
         $this->attributeCode = $attributeCode;
@@ -77,9 +77,9 @@ class OptionBuilder
     public static function anOption(string $attributeCode): OptionBuilder
     {
         $objectManager = Bootstrap::getObjectManager();
-        /** @var AttributeOptionManagementInterface $attributeOptionManagement */
-        $attributeOptionManagement = $objectManager->create(AttributeOptionManagementInterface::class);
-        $items = $attributeOptionManagement->getItems(Product::ENTITY, $attributeCode);
+        /** @var AttributeOptionManagementInterface $optionManagement */
+        $optionManagement = $objectManager->create(AttributeOptionManagementInterface::class);
+        $items = $optionManagement->getItems(Product::ENTITY, $attributeCode);
 
         /** @var AttributeOptionLabelInterface $optionLabel */
         $optionLabel = $objectManager->create(AttributeOptionLabelInterface::class);
@@ -95,7 +95,7 @@ class OptionBuilder
         $option->setIsDefault(false);
 
         return new static(
-            $attributeOptionManagement,
+            $optionManagement,
             $option,
             $optionLabel,
             $attributeCode
@@ -172,7 +172,7 @@ class OptionBuilder
         $builder = clone $this;
 
         // add the option
-        $this->attributeOptionManagement->add(
+        $this->optionManagement->add(
             \Magento\Catalog\Model\Product::ENTITY,
             $builder->attributeCode,
             $builder->option

--- a/src/Catalog/OptionBuilder.php
+++ b/src/Catalog/OptionBuilder.php
@@ -84,7 +84,7 @@ class OptionBuilder
         /** @var AttributeOptionLabelInterface $optionLabel */
         $optionLabel = $objectManager->create(AttributeOptionLabelInterface::class);
         $label = uniqid('Name ', true);
-        $optionLabel->setStoreId(1);
+        $optionLabel->setStoreId(0);
         $optionLabel->setLabel($label);
 
         /** @var AttributeOption $option */

--- a/src/Catalog/OptionBuilder.php
+++ b/src/Catalog/OptionBuilder.php
@@ -74,7 +74,7 @@ class OptionBuilder
      * @throws \Magento\Framework\Exception\InputException
      * @throws \Magento\Framework\Exception\StateException
      */
-    public static function anOption(string $attributeCode): OptionBuilder
+    public static function anOptionFor(string $attributeCode): OptionBuilder
     {
         $objectManager = Bootstrap::getObjectManager();
         /** @var AttributeOptionManagementInterface $optionManagement */

--- a/src/Catalog/OptionBuilder.php
+++ b/src/Catalog/OptionBuilder.php
@@ -1,0 +1,205 @@
+<?php
+declare(strict_types=1);
+
+namespace TddWizard\Fixtures\Catalog;
+
+use Magento\Catalog\Api\ProductAttributeRepositoryInterface;
+use Magento\Eav\Api\AttributeOptionManagementInterface;
+use Magento\Eav\Api\Data\AttributeOptionInterface;
+use Magento\Eav\Api\Data\AttributeOptionLabelInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+
+/**
+ * Create a source-model option for an attribute.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class OptionBuilder
+{
+
+    /**
+     * @var AttributeOptionManagementInterface
+     */
+    private $attributeOptionManagement;
+
+    /**
+     * @var AttributeOptionInterface
+     */
+    private $option;
+
+    /**
+     * @var AttributeOptionLabelInterface
+     */
+    private $optionLabel;
+
+    /**
+     * @var string
+     */
+    private $attributeCode;
+
+    /**
+     * OptionBuilder constructor.
+     *
+     * @param AttributeOptionManagementInterface $attributeOptionManagement
+     * @param AttributeOptionInterface $option
+     * @param AttributeOptionLabelInterface $optionLabel
+     * @param string $attributeCode
+     */
+    public function __construct(
+        AttributeOptionManagementInterface $attributeOptionManagement,
+        AttributeOptionInterface $option,
+        AttributeOptionLabelInterface $optionLabel,
+        string $attributeCode
+    ) {
+        $this->attributeOptionManagement = $attributeOptionManagement;
+        $this->option = $option;
+        $this->optionLabel = $optionLabel;
+        $this->attributeCode = $attributeCode;
+    }
+
+    /**
+     * Clone the builder.
+     */
+    public function __clone()
+    {
+        $this->option = clone $this->option;
+    }
+
+    /**
+     * Create an option.
+     *
+     * @param string $attributeCode
+     * @return OptionBuilder
+     */
+    public static function anOption(string $attributeCode): OptionBuilder
+    {
+        $objectManager = Bootstrap::getObjectManager();
+
+        /** @var AttributeOptionLabelInterface $optionLabel */
+        $optionLabel = $objectManager->create(AttributeOptionLabelInterface::class);
+        $label = uniqid('Name ', true);
+        $optionLabel->setStoreId(0); // TODO: handle better
+        $optionLabel->setLabel($label);
+
+        /** @var AttributeOptionInterface $option */
+        $option = $objectManager->create(AttributeOptionInterface::class);
+        $option->setLabel($label);
+        $option->setStoreLabels([$optionLabel]);
+        $option->setSortOrder(0);
+        $option->setIsDefault(false);
+
+        return new static(
+            $objectManager->create(AttributeOptionManagementInterface::class),
+            $option,
+            $optionLabel,
+            $attributeCode
+        );
+    }
+
+    /**
+     * Set label.
+     *
+     * @param string $label
+     * @return OptionBuilder
+     */
+    public function withLabel(string $label): OptionBuilder
+    {
+        $builder = clone $this;
+        $builder->optionLabel->setLabel($label);
+        $builder->option->setStoreLabels([$builder->optionLabel]);
+        $builder->option->setLabel($label);
+
+        return $builder;
+    }
+
+    /**
+     * Set sort order.
+     *
+     * @param int $sortOrder
+     * @return OptionBuilder
+     */
+    public function withSortOrder(int $sortOrder): OptionBuilder
+    {
+        $builder = clone $this;
+        $builder->option->setSortOrder($sortOrder);
+
+        return $builder;
+    }
+
+    /**
+     * Set default.
+     *
+     * @param bool $isDefault
+     * @return OptionBuilder
+     */
+    public function withIsDefault(bool $isDefault): OptionBuilder
+    {
+        $builder = clone $this;
+        $builder->option->setIsDefault($isDefault);
+
+        return $builder;
+    }
+
+    /**
+     * Set store ID.
+     *
+     * @param int $storeId
+     * @return OptionBuilder
+     */
+    public function withStoreId(int $storeId): OptionBuilder
+    {
+        $builder = clone $this;
+        $builder->optionLabel->setStoreId($storeId);
+
+        return $builder;
+    }
+
+    /**
+     * Build the option and apply it to the attribute.
+     *
+     * @return int
+     * @throws \Magento\Framework\Exception\InputException
+     * @throws \Magento\Framework\Exception\StateException
+     */
+    public function build(): int
+    {
+        $builder = clone $this;
+
+        // add the option
+        $this->attributeOptionManagement->add(
+            \Magento\Catalog\Model\Product::ENTITY,
+            $builder->attributeCode,
+            $builder->option
+        );
+
+        return $this->getOptionId();
+    }
+
+    /**
+     * Get the option ID.
+     *
+     * @return int
+     */
+    private function getOptionId(): int
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        // the add option above does not return the option, so we need to retrieve it
+        $attributeRepository = $objectManager->get(ProductAttributeRepositoryInterface::class);
+        $attribute = $attributeRepository->get($this->attributeCode);
+        $attributeValues[$attribute->getAttributeId()] = [];
+
+        // We have to generate a new sourceModel instance each time through to prevent it from
+        // referencing its _options cache. No other way to get it to pick up newly-added values.
+        $tableFactory = $objectManager->get(\Magento\Eav\Model\Entity\Attribute\Source\TableFactory::class);
+        $sourceModel = $tableFactory->create();
+        $sourceModel->setAttribute($attribute);
+        foreach ($sourceModel->getAllOptions() as $option) {
+            $attributeValues[$attribute->getAttributeId()][$option['label']] = $option['value'];
+        }
+        if (isset($attributeValues[$attribute->getAttributeId()][$this->optionLabel->getLabel()])) {
+            return (int)$attributeValues[$attribute->getAttributeId()][$this->optionLabel->getLabel()];
+        }
+
+        throw new \RuntimeException('Error building option');
+    }
+}

--- a/src/Catalog/OptionBuilder.php
+++ b/src/Catalog/OptionBuilder.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 namespace TddWizard\Fixtures\Catalog;
 
 use Magento\Catalog\Api\ProductAttributeRepositoryInterface;
+use Magento\Catalog\Model\Product;
 use Magento\Eav\Api\AttributeOptionManagementInterface;
-use Magento\Eav\Api\Data\AttributeOptionInterface;
 use Magento\Eav\Api\Data\AttributeOptionLabelInterface;
 use Magento\Eav\Model\Entity\Attribute\Option as AttributeOption;
 use Magento\TestFramework\Helper\Bootstrap;
@@ -71,22 +71,24 @@ class OptionBuilder
      *
      * @param string $attributeCode
      * @return OptionBuilder
+     * @throws \Magento\Framework\Exception\InputException
+     * @throws \Magento\Framework\Exception\StateException
      */
     public static function anOption(string $attributeCode): OptionBuilder
     {
         $objectManager = Bootstrap::getObjectManager();
         /** @var AttributeOptionManagementInterface $attributeOptionManagement */
         $attributeOptionManagement = $objectManager->create(AttributeOptionManagementInterface::class);
-        $items = $attributeOptionManagement->getItems();
+        $items = $attributeOptionManagement->getItems(Product::ENTITY, $attributeCode);
 
         /** @var AttributeOptionLabelInterface $optionLabel */
         $optionLabel = $objectManager->create(AttributeOptionLabelInterface::class);
         $label = uniqid('Name ', true);
-        $optionLabel->setStoreId(0); // TODO: handle better
+        $optionLabel->setStoreId(1);
         $optionLabel->setLabel($label);
 
-        /** @var AttributeOptionInterface $option */
-        $option = $objectManager->create(AttributeOptionInterface::class);
+        /** @var AttributeOption $option */
+        $option = $objectManager->create(AttributeOption::class);
         $option->setLabel($label);
         $option->setStoreLabels([$optionLabel]);
         $option->setSortOrder(count($items) + 1);
@@ -110,7 +112,7 @@ class OptionBuilder
     {
         $builder = clone $this;
         $builder->optionLabel->setLabel($label);
-        $builder->option->setStoreLabels([$builder->optionLabel]); // TODO: handle multistore
+        $builder->option->setStoreLabels([$builder->optionLabel]);
         $builder->option->setLabel($label);
 
         return $builder;
@@ -165,7 +167,7 @@ class OptionBuilder
      * @throws \Magento\Framework\Exception\InputException
      * @throws \Magento\Framework\Exception\StateException
      */
-    public function build(): int
+    public function build(): AttributeOption
     {
         $builder = clone $this;
 

--- a/src/Catalog/OptionFixture.php
+++ b/src/Catalog/OptionFixture.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+namespace TddWizard\Fixtures\Catalog;
+
+/**
+ * Class OptionFixture
+ */
+class OptionFixture
+{
+
+    /**
+     * @var int
+     */
+    private $optionId;
+
+    /**
+     * @var string
+     */
+    private $attributeCode;
+
+    /**
+     * OptionFixture constructor.
+     *
+     * @param int $optionId
+     * @param string $attributeCode
+     */
+    public function __construct(int $optionId, string $attributeCode)
+    {
+        $this->optionId = $optionId;
+        $this->attributeCode = $attributeCode;
+    }
+
+    /**
+     * Get the option ID.
+     *
+     * @return int
+     */
+    public function getOptionId(): int
+    {
+        return $this->optionId;
+    }
+
+    /**
+     * Get the attribute code.
+     *
+     * @return string
+     */
+    public function getAttributeCode(): string
+    {
+        return $this->attributeCode;
+    }
+
+    /**
+     * Rollback the option(s).
+     *
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function rollback(): void
+    {
+        OptionFixtureRollback::create()->execute($this);
+    }
+}

--- a/src/Catalog/OptionFixture.php
+++ b/src/Catalog/OptionFixture.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace TddWizard\Fixtures\Catalog;
 
 use Magento\Eav\Model\Entity\Attribute\Option as AttributeOption;
+use Magento\Framework\Exception\LocalizedException;
 
 /**
  * Class OptionFixture
@@ -24,7 +25,7 @@ class OptionFixture
     /**
      * OptionFixture constructor.
      *
-     * @param int $optionId
+     * @param AttributeOption $option
      * @param string $attributeCode
      */
     public function __construct(AttributeOption $option, string $attributeCode)
@@ -56,7 +57,7 @@ class OptionFixture
     /**
      * Rollback the option(s).
      *
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      */
     public function rollback(): void
     {

--- a/src/Catalog/OptionFixture.php
+++ b/src/Catalog/OptionFixture.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace TddWizard\Fixtures\Catalog;
 
+use Magento\Eav\Model\Entity\Attribute\Option as AttributeOption;
+
 /**
  * Class OptionFixture
  */
@@ -10,14 +12,14 @@ class OptionFixture
 {
 
     /**
-     * @var int
-     */
-    private $optionId;
-
-    /**
      * @var string
      */
     private $attributeCode;
+
+    /**
+     * @var AttributeOption
+     */
+    private $option;
 
     /**
      * OptionFixture constructor.
@@ -25,20 +27,10 @@ class OptionFixture
      * @param int $optionId
      * @param string $attributeCode
      */
-    public function __construct(int $optionId, string $attributeCode)
+    public function __construct(AttributeOption $option, string $attributeCode)
     {
-        $this->optionId = $optionId;
         $this->attributeCode = $attributeCode;
-    }
-
-    /**
-     * Get the option ID.
-     *
-     * @return int
-     */
-    public function getOptionId(): int
-    {
-        return $this->optionId;
+        $this->option = $option;
     }
 
     /**
@@ -49,6 +41,16 @@ class OptionFixture
     public function getAttributeCode(): string
     {
         return $this->attributeCode;
+    }
+
+    /**
+     * Get the option.
+     *
+     * @return AttributeOption
+     */
+    public function getOption(): AttributeOption
+    {
+        return $this->option;
     }
 
     /**

--- a/src/Catalog/OptionFixturePool.php
+++ b/src/Catalog/OptionFixturePool.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace TddWizard\Fixtures\Catalog;
+
+use Magento\Eav\Model\Entity\Attribute\Option as AttributeOption;
+use function array_values as values;
+
+/**
+ * Class OptionFixturePool
+ */
+class OptionFixturePool
+{
+
+    /**
+     * @var OptionFixture[]
+     */
+    private $optionFixtures = [];
+
+    public function add(AttributeOption $option, string $attributecode, string $key = null): void
+    {
+        if ($key === null) {
+            $this->optionFixtures[] = new OptionFixture($option, $attributecode);
+        } else {
+            $this->optionFixtures[$key] = new OptionFixture($option, $attributecode);
+        }
+    }
+
+    /**
+     * Returns option fixture by key, or last added if key not specified
+     *
+     * @param string|null $key
+     * @return OptionFixture
+     */
+    public function get(string $key = null): OptionFixture
+    {
+        if ($key === null) {
+            $key = \array_key_last($this->optionFixtures);
+        }
+        if ($key === null || !\array_key_exists($key, $this->optionFixtures)) {
+            throw new \OutOfBoundsException('No matching option found in fixture pool');
+        }
+        return $this->optionFixtures[$key];
+    }
+
+    public function rollback(): void
+    {
+        OptionFixtureRollback::create()->execute(...values($this->optionFixtures));
+        $this->optionFixtures = [];
+    }
+}

--- a/src/Catalog/OptionFixtureRollback.php
+++ b/src/Catalog/OptionFixtureRollback.php
@@ -46,8 +46,7 @@ class OptionFixtureRollback
      *
      * @return OptionFixtureRollback
      */
-    public static function create():
-    OptionFixtureRollback //phpcs:ignore Magento2.Functions.StaticFunction.StaticFunction
+    public static function create(): OptionFixtureRollback
     {
         $objectManager = Bootstrap::getObjectManager();
         return new self(

--- a/src/Catalog/OptionFixtureRollback.php
+++ b/src/Catalog/OptionFixtureRollback.php
@@ -27,18 +27,18 @@ class OptionFixtureRollback
     /**
      * @var AttributeOptionManagementInterface
      */
-    private $attributeOptionManagement;
+    private $optionManagement;
 
     /**
      * OptionFixtureRollback constructor.
      *
      * @param Registry $registry
-     * @param AttributeOptionManagementInterface $attributeOptionManagement
+     * @param AttributeOptionManagementInterface $optionManagement
      */
-    public function __construct(Registry $registry, AttributeOptionManagementInterface $attributeOptionManagement)
+    public function __construct(Registry $registry, AttributeOptionManagementInterface $optionManagement)
     {
         $this->registry = $registry;
-        $this->attributeOptionManagement = $attributeOptionManagement;
+        $this->optionManagement = $optionManagement;
     }
 
     /**
@@ -69,7 +69,7 @@ class OptionFixtureRollback
         $this->registry->register('isSecureArea', true);
 
         foreach ($optionFixtures as $optionFixture) {
-            $this->attributeOptionManagement->delete(
+            $this->optionManagement->delete(
                 Product::ENTITY,
                 $optionFixture->getAttributeCode(),
                 $optionFixture->getOption()->getId()

--- a/src/Catalog/OptionFixtureRollback.php
+++ b/src/Catalog/OptionFixtureRollback.php
@@ -3,8 +3,6 @@ declare(strict_types=1);
 
 namespace TddWizard\Fixtures\Catalog;
 
-namespace Coffee\FixtureBuilders\Catalog;
-
 use Magento\Catalog\Model\Product;
 use Magento\Eav\Api\AttributeOptionManagementInterface;
 use Magento\Framework\Exception\InputException;
@@ -75,7 +73,7 @@ class OptionFixtureRollback
             $this->attributeOptionManagement->delete(
                 Product::ENTITY,
                 $optionFixture->getAttributeCode(),
-                $optionFixture->getOptionId()
+                $optionFixture->getOption()->getId()
             );
         }
 

--- a/src/Catalog/OptionFixtureRollback.php
+++ b/src/Catalog/OptionFixtureRollback.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+namespace TddWizard\Fixtures\Catalog;
+
+namespace Coffee\FixtureBuilders\Catalog;
+
+use Magento\Catalog\Model\Product;
+use Magento\Eav\Api\AttributeOptionManagementInterface;
+use Magento\Framework\Exception\InputException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Exception\StateException;
+use Magento\Framework\Registry;
+use Magento\TestFramework\Helper\Bootstrap;
+
+/**
+ * Roll back one or more options.
+ *
+ * @internal Use OptionFixture::rollback() instead.
+ */
+class OptionFixtureRollback
+{
+
+    /**
+     * @var Registry
+     */
+    private $registry;
+
+    /**
+     * @var AttributeOptionManagementInterface
+     */
+    private $attributeOptionManagement;
+
+    /**
+     * OptionFixtureRollback constructor.
+     *
+     * @param Registry $registry
+     * @param AttributeOptionManagementInterface $attributeOptionManagement
+     */
+    public function __construct(Registry $registry, AttributeOptionManagementInterface $attributeOptionManagement)
+    {
+        $this->registry = $registry;
+        $this->attributeOptionManagement = $attributeOptionManagement;
+    }
+
+    /**
+     * Create the object.
+     *
+     * @return OptionFixtureRollback
+     */
+    public static function create():
+    OptionFixtureRollback //phpcs:ignore Magento2.Functions.StaticFunction.StaticFunction
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        return new self(
+            $objectManager->get(Registry::class),
+            $objectManager->get(AttributeOptionManagementInterface::class)
+        );
+    }
+
+    /**
+     * Remove the given option(s).
+     *
+     * @param OptionFixture ...$optionFixtures
+     * @throws InputException
+     * @throws NoSuchEntityException
+     * @throws StateException
+     */
+    public function execute(OptionFixture ...$optionFixtures): void
+    {
+        $this->registry->unregister('isSecureArea');
+        $this->registry->register('isSecureArea', true);
+
+        foreach ($optionFixtures as $optionFixture) {
+            $this->attributeOptionManagement->delete(
+                Product::ENTITY,
+                $optionFixture->getAttributeCode(),
+                $optionFixture->getOptionId()
+            );
+        }
+
+        $this->registry->unregister('isSecureArea');
+    }
+}

--- a/tests/Catalog/OptionBuilderTest.php
+++ b/tests/Catalog/OptionBuilderTest.php
@@ -42,7 +42,7 @@ class OptionBuilderTest extends TestCase
     {
         if (!empty($this->options)) {
             foreach ($this->options as $optionFixture) {
-                OptionFixtureRollback::create()->execute($optionFixture);
+                $optionFixture->rollBack();
             }
         }
     }
@@ -54,7 +54,7 @@ class OptionBuilderTest extends TestCase
     {
         $userDefinedAttributeCode = 'dropdown_attribute';
         $optionFixture = new OptionFixture(
-            OptionBuilder::anOption($userDefinedAttributeCode)->build(),
+            OptionBuilder::anOptionFor($userDefinedAttributeCode)->build(),
             $userDefinedAttributeCode
         );
         $this->options[] = $optionFixture;
@@ -74,7 +74,7 @@ class OptionBuilderTest extends TestCase
         $userDefinedAttributeCode = 'dropdown_attribute';
         $label = uniqid('Label ', true);
         $optionFixture = new OptionFixture(
-            OptionBuilder::anOption($userDefinedAttributeCode)->withLabel($label)->build(),
+            OptionBuilder::anOptionFor($userDefinedAttributeCode)->withLabel($label)->build(),
             $userDefinedAttributeCode
         );
         $this->options[] = $optionFixture;

--- a/tests/Catalog/OptionBuilderTest.php
+++ b/tests/Catalog/OptionBuilderTest.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace TddWizard\Fixtures\Catalog;
+
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @magentoAppIsolation enabled
+ * @magentoDbIsolation enabled
+ */
+class OptionBuilderTest extends TestCase
+{
+
+}

--- a/tests/Catalog/OptionBuilderTest.php
+++ b/tests/Catalog/OptionBuilderTest.php
@@ -3,6 +3,10 @@ declare(strict_types=1);
 
 namespace TddWizard\Fixtures\Catalog;
 
+use Magento\Eav\Model\Entity\Attribute\OptionFactory;
+use Magento\Eav\Model\ResourceModel\Entity\Attribute\Option as OptionResource;
+use TddWizard\Fixtures\Catalog\OptionFixtureRollback;
+use Magento\Eav\Api\AttributeOptionManagementInterface;
 use Magento\TestFramework\Helper\Bootstrap;
 use PHPUnit\Framework\TestCase;
 
@@ -13,4 +17,62 @@ use PHPUnit\Framework\TestCase;
 class OptionBuilderTest extends TestCase
 {
 
+    private $options = [];
+
+    /** @var AttributeOptionManagementInterface */
+    private $attributeOptionManagement;
+
+    /** @var OptionResource */
+    private $optionResourceModel;
+
+    /** @var OptionFactory */
+    private $optionFactory;
+
+    protected function setUp(): void
+    {
+        $this->objectManager = Bootstrap::getObjectManager();
+        $this->attributeOptionManagement = $this->objectManager->get(AttributeOptionManagementInterface::class);
+        $this->optionFactory = $this->objectManager->get(OptionFactory::class);
+        $this->optionResourceModel = $this->objectManager->get(OptionResource::class);
+    }
+
+    protected function tearDown(): void
+    {
+        if (! empty($this->options)) {
+            foreach ($this->options as $optionFixture) {
+                OptionFixtureRollback::create()->execute($optionFixture);
+            }
+        }
+    }
+
+    /**
+     * @magentoDataFixture Magento/Catalog/_files/dropdown_attribute.php
+     */
+    public function testAddOption()
+    {
+        /*
+         * Values from core fixture files
+         */
+        $userDefinedAttributeCode = 'dropdown_attribute';
+        $optionFixture = new OptionFixture(
+            OptionBuilder::anOption($userDefinedAttributeCode)->build(), $userDefinedAttributeCode
+        );
+        $this->options[] = $optionFixture;
+
+        /** @var \Magento\Eav\Model\Entity\Attribute\Option $option */
+        $option = $this->optionFactory->create();
+        $this->optionResourceModel->load($option, $optionFixture->getOptionId());
+
+        self::assertEquals($optionFixture->getOption->getId()(), $option->getId());
+//        $savedItem = null;
+//        foreach ($items as $item)
+//        {
+//            if ($item->getLabel() === $optionFixture->getOptionLabel()) {
+//                $savedItem = $item;
+//                break;
+//            }
+//        }
+//        self::assertNotNull($savedItem);
+
+    }
 }

--- a/tests/Catalog/OptionBuilderTest.php
+++ b/tests/Catalog/OptionBuilderTest.php
@@ -3,11 +3,13 @@ declare(strict_types=1);
 
 namespace TddWizard\Fixtures\Catalog;
 
+use TddWizard\Fixtures\Catalog\OptionBuilder;
+use TddWizard\Fixtures\Catalog\OptionFixture;
+use TddWizard\Fixtures\Catalog\OptionFixtureRollback;
 use Magento\Catalog\Model\Product;
+use Magento\Eav\Api\AttributeOptionManagementInterface;
 use Magento\Eav\Model\Entity\Attribute\OptionFactory;
 use Magento\Eav\Model\ResourceModel\Entity\Attribute\Option as OptionResource;
-use TddWizard\Fixtures\Catalog\OptionFixtureRollback;
-use Magento\Eav\Api\AttributeOptionManagementInterface;
 use Magento\TestFramework\Helper\Bootstrap;
 use PHPUnit\Framework\TestCase;
 
@@ -17,7 +19,6 @@ use PHPUnit\Framework\TestCase;
  */
 class OptionBuilderTest extends TestCase
 {
-
     private $options = [];
 
     /** @var AttributeOptionManagementInterface */
@@ -31,10 +32,10 @@ class OptionBuilderTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->objectManager = Bootstrap::getObjectManager();
-        $this->attributeOptionManagement = $this->objectManager->get(AttributeOptionManagementInterface::class);
-        $this->optionFactory = $this->objectManager->get(OptionFactory::class);
-        $this->optionResourceModel = $this->objectManager->get(OptionResource::class);
+        $objectManager = Bootstrap::getObjectManager();
+        $this->attributeOptionManagement = $objectManager->get(AttributeOptionManagementInterface::class);
+        $this->optionFactory = $objectManager->get(OptionFactory::class);
+        $this->optionResourceModel = $objectManager->get(OptionResource::class);
     }
 
     protected function tearDown(): void
@@ -49,11 +50,12 @@ class OptionBuilderTest extends TestCase
     /**
      * @magentoDataFixture Magento/Catalog/_files/dropdown_attribute.php
      */
-    public function testAddOption()
+    public function testAddOption(): void
     {
         $userDefinedAttributeCode = 'dropdown_attribute';
         $optionFixture = new OptionFixture(
-            OptionBuilder::anOption($userDefinedAttributeCode)->build(), $userDefinedAttributeCode
+            OptionBuilder::anOption($userDefinedAttributeCode)->build(),
+            $userDefinedAttributeCode
         );
         $this->options[] = $optionFixture;
 
@@ -67,12 +69,13 @@ class OptionBuilderTest extends TestCase
     /**
      * @magentoDataFixture Magento/Catalog/_files/dropdown_attribute.php
      */
-    public function testAddOptionWithLabel()
+    public function testAddOptionWithLabel(): void
     {
         $userDefinedAttributeCode = 'dropdown_attribute';
         $label = uniqid('Label ', true);
         $optionFixture = new OptionFixture(
-            OptionBuilder::anOption($userDefinedAttributeCode)->withLabel($label)->build(), $userDefinedAttributeCode
+            OptionBuilder::anOption($userDefinedAttributeCode)->withLabel($label)->build(),
+            $userDefinedAttributeCode
         );
         $this->options[] = $optionFixture;
 

--- a/tests/Catalog/OptionBuilderTest.php
+++ b/tests/Catalog/OptionBuilderTest.php
@@ -21,8 +21,8 @@ class OptionBuilderTest extends TestCase
 {
     private $options = [];
 
-    /** @var AttributeOptionManagementInterface */
-    private $attributeOptionManagement;
+    /** @var AttributeOptionManagementoptionManagemente */
+    private $optionManagement;
 
     /** @var OptionResource */
     private $optionResourceModel;
@@ -33,7 +33,7 @@ class OptionBuilderTest extends TestCase
     protected function setUp(): void
     {
         $objectManager = Bootstrap::getObjectManager();
-        $this->attributeOptionManagement = $objectManager->get(AttributeOptionManagementInterface::class);
+        $this->optionManagement = $objectManager->get(AttributeOptionManagementInterface::class);
         $this->optionFactory = $objectManager->get(OptionFactory::class);
         $this->optionResourceModel = $objectManager->get(OptionResource::class);
     }
@@ -83,7 +83,7 @@ class OptionBuilderTest extends TestCase
         $option = $this->optionFactory->create();
         $this->optionResourceModel->load($option, $optionFixture->getOption()->getId());
 
-        $items = $this->attributeOptionManagement->getItems(Product::ENTITY, $userDefinedAttributeCode);
+        $items = $this->optionManagement->getItems(Product::ENTITY, $userDefinedAttributeCode);
 
         self::assertEquals($optionFixture->getOption()->getId(), $option->getId());
         $foundLabel = false;

--- a/tests/Catalog/OptionFixturePoolTest.php
+++ b/tests/Catalog/OptionFixturePoolTest.php
@@ -1,0 +1,134 @@
+<?php
+declare(strict_types=1);
+
+namespace TddWizard\Fixtures\Catalog;
+
+use TddWizard\Fixtures\Catalog\OptionBuilder;
+use TddWizard\Fixtures\Catalog\OptionFixturePool;
+use Magento\Eav\Model\Entity\Attribute\Option as AttributeOption;
+use Magento\Eav\Model\Entity\Attribute\OptionFactory as AttributeOptionFactory;
+use Magento\Eav\Model\ResourceModel\Entity\Attribute\Option as OptionResource;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @magentoAppIsolation enabled
+ * @magentoDbIsolation enabled
+ */
+class OptionFixturePoolTest extends TestCase
+{
+
+    /**
+     * @var OptionFixturePool
+     */
+    private $optionFixtures;
+
+    /**
+     * @var OptionResource
+     */
+    private $optionResourceModel;
+
+    /**
+     * @var string
+     */
+    private $dbAttributeCode = 'dropdown_attribute';
+
+    /**
+     * @var AttributeOptionFactory
+     */
+    private $optionFactory;
+
+    protected function setUp(): void
+    {
+        $this->optionFixtures = new OptionFixturePool();
+        $this->optionFactory = Bootstrap::getObjectManager()->get(AttributeOptionFactory::class);
+        $this->optionResourceModel = Bootstrap::getObjectManager()->get(OptionResource::class);
+    }
+
+    public function testLastOptionFixtureReturnedByDefault(): void
+    {
+        $firstOption = $this->createOption();
+        $lastOption = $this->createOption();
+        $this->optionFixtures->add($firstOption, 'option_1');
+        $this->optionFixtures->add($lastOption, 'option_2');
+        $optionFixture = $this->optionFixtures->get();
+        self::assertEquals($lastOption->getId(), $optionFixture->getOption()->getId());
+    }
+
+    public function testExceptionThrownWhenAccessingEmptyOptionPool(): void
+    {
+        $this->expectException(\OutOfBoundsException::class);
+        $this->optionFixtures->get();
+    }
+
+    public function testOptionFixtureReturnedByKey(): void
+    {
+        $firstOption = $this->createOption();
+        $lastOption = $this->createOption();
+        $this->optionFixtures->add($firstOption, 'option_1', 'first');
+        $this->optionFixtures->add($lastOption, 'option_2', 'last');
+        $optionFixture = $this->optionFixtures->get('first');
+        self::assertEquals($firstOption->getId(), $optionFixture->getOption()->getId());
+    }
+
+    public function testExceptionThrownWhenAccessingNonexistingKey(): void
+    {
+        $option = $this->createOption();
+        $this->optionFixtures->add($option, 'option_1', 'foo');
+        $this->expectException(\OutOfBoundsException::class);
+        $this->optionFixtures->get('bar');
+    }
+
+    /**
+     * @magentoDataFixture Magento/Catalog/_files/dropdown_attribute.php
+     */
+    public function testRollbackRemovesOptionsFromPool(): void
+    {
+        $option = $this->createOptionInDb($this->dbAttributeCode);
+        $this->optionFixtures->add($option, $this->dbAttributeCode);
+        $this->optionFixtures->rollback();
+        $this->expectException(\OutOfBoundsException::class);
+        $this->optionFixtures->get();
+    }
+
+    /**
+     * @magentoDataFixture Magento/Catalog/_files/dropdown_attribute.php
+     */
+    public function testRollbackDeletesOptionsFromDb(): void
+    {
+        $option = $this->createOptionInDb($this->dbAttributeCode);
+        $this->optionFixtures->add($option, $this->dbAttributeCode);
+        $this->optionFixtures->rollback();
+        $option = $this->optionFactory->create();
+        $this->optionResourceModel->load($option, $option->getId());
+        self::assertEmpty($option->getId());
+    }
+
+    /**
+     * Creates a dummy option object
+     *
+     * @return AttributeOption
+     */
+    private function createOption(): AttributeOption
+    {
+        static $nextId = 1;
+        /** @var AttributeOption $option */
+        $option = Bootstrap::getObjectManager()->create(AttributeOption::class);
+        $option->setId($nextId++);
+
+        return $option;
+    }
+
+    /**
+     * Uses builder to create a customer
+     *
+     * @param string $attributeCode
+     * @return AttributeOption
+     * @throws \Magento\Framework\Exception\InputException
+     * @throws \Magento\Framework\Exception\StateException
+     */
+    private function createOptionInDb(string $attributeCode): AttributeOption
+    {
+        return OptionBuilder::anOptionFor($attributeCode)->withLabel('Testing')->build();
+    }
+}

--- a/tests/Catalog/OptionFixtureRollbackTest.php
+++ b/tests/Catalog/OptionFixtureRollbackTest.php
@@ -38,7 +38,7 @@ class OptionFixtureRollbackTest extends TestCase
     {
         $userDefinedAttributeCode = 'dropdown_attribute';
         $optionFixture = new OptionFixture(
-            OptionBuilder::anOption($userDefinedAttributeCode)->build(),
+            OptionBuilder::anOptionFor($userDefinedAttributeCode)->build(),
             $userDefinedAttributeCode
         );
         OptionFixtureRollback::create()->execute($optionFixture);
@@ -56,11 +56,11 @@ class OptionFixtureRollbackTest extends TestCase
     {
         $userDefinedAttributeCode = 'dropdown_attribute';
         $optionFixture = new OptionFixture(
-            OptionBuilder::anOption($userDefinedAttributeCode)->build(),
+            OptionBuilder::anOptionFor($userDefinedAttributeCode)->build(),
             $userDefinedAttributeCode
         );
         $otherOptionFixture = new OptionFixture(
-            OptionBuilder::anOption($userDefinedAttributeCode)->build(),
+            OptionBuilder::anOptionFor($userDefinedAttributeCode)->build(),
             $userDefinedAttributeCode
         );
         OptionFixtureRollback::create()->execute($optionFixture, $otherOptionFixture);

--- a/tests/Catalog/OptionFixtureRollbackTest.php
+++ b/tests/Catalog/OptionFixtureRollbackTest.php
@@ -1,10 +1,13 @@
 <?php
+declare(strict_types=1);
 
 namespace TddWizard\Fixtures\Catalog;
 
+use TddWizard\Fixtures\Catalog\OptionBuilder;
+use TddWizard\Fixtures\Catalog\OptionFixture;
+use TddWizard\Fixtures\Catalog\OptionFixtureRollback;
 use Magento\Eav\Model\Entity\Attribute\OptionFactory;
 use Magento\Eav\Model\ResourceModel\Entity\Attribute\Option as OptionResource;
-use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\TestFramework\Helper\Bootstrap;
 use PHPUnit\Framework\TestCase;
 
@@ -31,11 +34,12 @@ class OptionFixtureRollbackTest extends TestCase
     /**
      * @magentoDataFixture Magento/Catalog/_files/dropdown_attribute.php
      */
-    public function testRollbackSingleOptionFixture()
+    public function testRollbackSingleOptionFixture(): void
     {
         $userDefinedAttributeCode = 'dropdown_attribute';
         $optionFixture = new OptionFixture(
-            OptionBuilder::anOption($userDefinedAttributeCode)->build(), $userDefinedAttributeCode
+            OptionBuilder::anOption($userDefinedAttributeCode)->build(),
+            $userDefinedAttributeCode
         );
         OptionFixtureRollback::create()->execute($optionFixture);
 
@@ -48,14 +52,16 @@ class OptionFixtureRollbackTest extends TestCase
     /**
      * @magentoDataFixture Magento/Catalog/_files/dropdown_attribute.php
      */
-    public function testRollbackMultipleOptionFixtures()
+    public function testRollbackMultipleOptionFixtures(): void
     {
         $userDefinedAttributeCode = 'dropdown_attribute';
         $optionFixture = new OptionFixture(
-            OptionBuilder::anOption($userDefinedAttributeCode)->build(), $userDefinedAttributeCode
+            OptionBuilder::anOption($userDefinedAttributeCode)->build(),
+            $userDefinedAttributeCode
         );
         $otherOptionFixture = new OptionFixture(
-            OptionBuilder::anOption($userDefinedAttributeCode)->build(), $userDefinedAttributeCode
+            OptionBuilder::anOption($userDefinedAttributeCode)->build(),
+            $userDefinedAttributeCode
         );
         OptionFixtureRollback::create()->execute($optionFixture, $otherOptionFixture);
 

--- a/tests/Catalog/OptionFixtureRollbackTest.php
+++ b/tests/Catalog/OptionFixtureRollbackTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace TddWizard\Fixtures\Catalog;
+
+use Magento\Eav\Model\Entity\Attribute\OptionFactory;
+use Magento\Eav\Model\ResourceModel\Entity\Attribute\Option as OptionResource;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @magentoAppIsolation enabled
+ * @magentoDbIsolation enabled
+ */
+class OptionFixtureRollbackTest extends TestCase
+{
+
+    /** @var OptionResource */
+    private $optionResourceModel;
+
+    /** @var OptionFactory */
+    private $optionFactory;
+
+    protected function setUp(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        $this->optionFactory = $objectManager->get(OptionFactory::class);
+        $this->optionResourceModel = $objectManager->get(OptionResource::class);
+    }
+
+    /**
+     * @magentoDataFixture Magento/Catalog/_files/dropdown_attribute.php
+     */
+    public function testRollbackSingleOptionFixture()
+    {
+        $userDefinedAttributeCode = 'dropdown_attribute';
+        $optionFixture = new OptionFixture(
+            OptionBuilder::anOption($userDefinedAttributeCode)->build(), $userDefinedAttributeCode
+        );
+        OptionFixtureRollback::create()->execute($optionFixture);
+
+        /** @var \Magento\Eav\Model\Entity\Attribute\Option $option */
+        $option = $this->optionFactory->create();
+        $this->optionResourceModel->load($option, $optionFixture->getOption()->getId());
+        self::assertNull($option->getId());
+    }
+
+    /**
+     * @magentoDataFixture Magento/Catalog/_files/dropdown_attribute.php
+     */
+    public function testRollbackMultipleOptionFixtures()
+    {
+        $userDefinedAttributeCode = 'dropdown_attribute';
+        $optionFixture = new OptionFixture(
+            OptionBuilder::anOption($userDefinedAttributeCode)->build(), $userDefinedAttributeCode
+        );
+        $otherOptionFixture = new OptionFixture(
+            OptionBuilder::anOption($userDefinedAttributeCode)->build(), $userDefinedAttributeCode
+        );
+        OptionFixtureRollback::create()->execute($optionFixture, $otherOptionFixture);
+
+        /** @var \Magento\Eav\Model\Entity\Attribute\Option $option */
+        $option = $this->optionFactory->create();
+        $this->optionResourceModel->load($option, $optionFixture->getOption()->getId());
+        self::assertNull($option->getId());
+
+        $this->optionResourceModel->load($option, $otherOptionFixture->getOption()->getId());
+        self::assertNull($option->getId());
+    }
+}


### PR DESCRIPTION
I've been running into an issue where I need to test product attributes that use options (not from a custom database source model). This PR adds the ability to add options to the database for a given attribute.