### PR TITLE
add build without save method for products

### DIFF
--- a/src/Catalog/ProductBuilder.php
+++ b/src/Catalog/ProductBuilder.php
@@ -314,6 +314,20 @@ class ProductBuilder
 
     /**
      * @return ProductInterface
+     */
+    public function buildWithoutSave() : ProductInterface
+    {
+        if (!$this->product->getSku()) {
+            $this->product->setSku(sha1(uniqid('', true)));
+        }
+        $this->product->setCustomAttribute('url_key', $this->product->getSku());
+        $this->product->setData('category_ids', $this->categoryIds);
+
+        return clone $this->product;
+    }
+
+    /**
+     * @return ProductInterface
      * @throws Exception
      */
     private function createProduct(): ProductInterface

--- a/tests/Catalog/ProductBuilderTest.php
+++ b/tests/Catalog/ProductBuilderTest.php
@@ -220,15 +220,25 @@ class ProductBuilderTest extends TestCase
         $productFixture = new ProductFixture(
             $builder->build()
         );
-        $this->assertRegExp('/[0-9a-f]{32}/', $productFixture->getSku());
+        $this->assertMatchesRegularExpression('/[0-9a-f]{32}/', $productFixture->getSku());
         $this->products[] = $productFixture;
 
         $otherProductFixture = new ProductFixture(
             $builder->build()
         );
-        $this->assertRegExp('/[0-9a-f]{32}/', $otherProductFixture->getSku());
+        $this->assertMatchesRegularExpression('/[0-9a-f]{32}/', $otherProductFixture->getSku());
         $this->assertNotEquals($productFixture->getSku(), $otherProductFixture->getSku());
         $this->products[] = $otherProductFixture;
+    }
+
+    public function testRandomSkuOnBuildWithoutSave()
+    {
+        $product = ProductBuilder::aSimpleProduct()->buildWithoutSave();
+        $this->assertMatchesRegularExpression('/[0-9a-f]{32}/', $product->getSku());
+
+        $otherProduct = ProductBuilder::aSimpleProduct()->buildWithoutSave();
+        $this->assertMatchesRegularExpression('/[0-9a-f]{32}/', $otherProduct->getSku());
+        $this->assertNotEquals($product->getSku(), $otherProduct->getSku());
     }
 
     public function testProductCanBeLoadedWithCollection()

--- a/tests/Catalog/ProductBuilderTest.php
+++ b/tests/Catalog/ProductBuilderTest.php
@@ -220,13 +220,13 @@ class ProductBuilderTest extends TestCase
         $productFixture = new ProductFixture(
             $builder->build()
         );
-        $this->assertMatchesRegularExpression('/[0-9a-f]{32}/', $productFixture->getSku());
+        $this->assertRegExp('/[0-9a-f]{32}/', $productFixture->getSku());
         $this->products[] = $productFixture;
 
         $otherProductFixture = new ProductFixture(
             $builder->build()
         );
-        $this->assertMatchesRegularExpression('/[0-9a-f]{32}/', $otherProductFixture->getSku());
+        $this->assertRegExp('/[0-9a-f]{32}/', $otherProductFixture->getSku());
         $this->assertNotEquals($productFixture->getSku(), $otherProductFixture->getSku());
         $this->products[] = $otherProductFixture;
     }
@@ -234,10 +234,10 @@ class ProductBuilderTest extends TestCase
     public function testRandomSkuOnBuildWithoutSave()
     {
         $product = ProductBuilder::aSimpleProduct()->buildWithoutSave();
-        $this->assertMatchesRegularExpression('/[0-9a-f]{32}/', $product->getSku());
+        $this->assertRegExp('/[0-9a-f]{32}/', $product->getSku());
 
         $otherProduct = ProductBuilder::aSimpleProduct()->buildWithoutSave();
-        $this->assertMatchesRegularExpression('/[0-9a-f]{32}/', $otherProduct->getSku());
+        $this->assertRegExp('/[0-9a-f]{32}/', $otherProduct->getSku());
         $this->assertNotEquals($product->getSku(), $otherProduct->getSku());
     }
 


### PR DESCRIPTION
This adds the ability to create a product without saving it. I tend to use this quite a bit in my own tests and I usually override the ProductBuilder in order to do that.