### PR TITLE
Ignore products in order rollback if already deleted

### DIFF
--- a/src/Sales/OrderFixtureRollback.php
+++ b/src/Sales/OrderFixtureRollback.php
@@ -82,7 +82,11 @@ class OrderFixtureRollback
             array_walk(
                 $orderItems,
                 function (OrderItemInterface $orderItem) {
-                    $this->productRepository->deleteById($orderItem->getSku());
+                    try {
+                        $this->productRepository->deleteById($orderItem->getSku());
+                    } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
+                        // ignore if already deleted
+                    }
                 }
             );
         }


### PR DESCRIPTION
May happen through separate product fixture rollback or if multiple orders are created with the same product